### PR TITLE
SteamOS input number fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import Updater from './backend/updater'
 
 import { OpentrackPluginBackend as OpentrackPlugin } from './plugins/backend/opentrack'
 import { WebuiPluginBackend as WebuiPlugin } from './plugins/backend/webui'
+import * as path from 'path';
 
 declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
@@ -41,6 +42,20 @@ const createWindow = (): void => {
   });
 
   mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
+
+  if (process.platform !== 'darwin' && process.platform !== 'win32') {
+    // setup SteamOS font injector script
+    mainWindow.webContents.setWindowOpenHandler(() => {
+      return {
+        action: 'allow',
+        overrideBrowserWindowOptions: {
+          webPreferences: {
+            preload: path.join(__dirname, 'preload.js')
+          }
+        }
+      }
+    });
+  }
 
   // Check if we already have tokens..
   console.log('tokenStore:', tokenStore)

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,0 +1,9 @@
+console.log('Preload script ready');
+
+window.addEventListener('load', function() {
+  // Load font because it is missing from the system fonts on linux
+  var linkElement = document.createElement('link');
+  linkElement.href = 'https://fonts.googleapis.com/css2?family=Roboto&display=swap;'
+  linkElement.rel = 'stylesheet';
+  document.head.append(linkElement);
+});

--- a/webpack.main.config.js
+++ b/webpack.main.config.js
@@ -6,6 +6,7 @@ module.exports = {
   entry: {
     index: './src/index.ts',
     webui: './src/webui.ts',
+    preload: './src/preload.ts',
   },
   // Put your normal webpack config below here
   module: {


### PR DESCRIPTION
#237 

On SteamOS the input font-family fallbacks to "Segoe UI Symbol" which does not contain number glyphs.

- Install  "Roboto"  font with Font Management app also works.
- If we delete the "Segoe UI Symbol" it works too.

<img width="451" alt="Screenshot 2022-06-21 at 1 40 56" src="https://user-images.githubusercontent.com/6617970/174689915-0ec2cfb1-a259-45da-a6a4-3baa8517d514.png">