### PR TITLE
Implement changes to support the Keyboard Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ The following keys are mapped as following:
     Dpad: Keypad direction controls
     Buttons: A, B, X, Y, Backspace (Mapped as B), Enter (Mapped as A)
     Nexus (Xbox button): N
-    Left bumper: [
-    Right bumper: ]
+    Left Bumper: [
+    Right Bumper: ]
+    Left Trigger: -
+    Right Trigger: =
     View: V
     Menu: M
 
@@ -42,7 +44,7 @@ The application also provides a way to see which of your friends are online. Thi
 
 ## Steam Deck Setup
 
-This application is reported to be working on the Steam Deck with some small bugs and side-effects.
+This application is reported to be working on the Steam Deck with some small bugs and side-effects. You can map one of the Steam Deck back buttons to the 'N' key to simulate the Xbox button.
 
 ### Optional launch arguments
 

--- a/renderer/pages/stream/[serverid].tsx
+++ b/renderer/pages/stream/[serverid].tsx
@@ -135,47 +135,6 @@ function Stream() {
     // Keyboard events
     const keyboardDownEvent = (e) => {
       switch(e.keyCode){
-        case 38:
-          xPlayer.getChannelProcessor('input').pressButton(0, { DPadUp: 1 })
-          break;
-        case 40:
-          xPlayer.getChannelProcessor('input').pressButton(0, { DPadDown: 1 })
-          break;
-        case 37:
-          xPlayer.getChannelProcessor('input').pressButton(0, { DPadLeft: 1 })
-          break;
-        case 39:
-          xPlayer.getChannelProcessor('input').pressButton(0, { DPadRight: 1 })
-          break;
-        case 13:
-        case 65:
-          xPlayer.getChannelProcessor('input').pressButton(0, { A: 1 })
-          break;
-        case 8:
-        case 66:
-          xPlayer.getChannelProcessor('input').pressButton(0, { B: 1 })
-          break;
-        case 88:
-          xPlayer.getChannelProcessor('input').pressButton(0, { X: 1 })
-          break;
-        case 89:
-          xPlayer.getChannelProcessor('input').pressButton(0, { Y: 1 })
-          break;
-        case 78:
-          xPlayer.getChannelProcessor('input').pressButton(0, { Nexus: 1 })
-          break;
-        case 219:
-          xPlayer.getChannelProcessor('input').pressButton(0, { LeftShoulder: 1 })
-          break;
-        case 221:
-          xPlayer.getChannelProcessor('input').pressButton(0, { RightShoulder: 1 })
-          break;
-        case 86:
-          xPlayer.getChannelProcessor('input').pressButton(0, { View: 1 })
-          break;
-        case 77:
-          xPlayer.getChannelProcessor('input').pressButton(0, { Menu: 1 })
-          break;
         case 48:
           xPlayer.getChannelProcessor('audio')._softReset()
           break;
@@ -193,14 +152,6 @@ function Stream() {
       if(keepaliveInterval){ clearInterval(keepaliveInterval) }
     };
   })
-
-  // Keyboard controls
-  // React.useEffect(() => {
-
-  //   return () => {
-  //     //
-  //   };
-  // })
 
   function gamepadSend(button){
     console.log('Press button:', button)


### PR DESCRIPTION
These are the associated changes to implement the Keyboard Driver that was added to xbox-xcloud-player in this [pull request](https://github.com/unknownskl/xbox-xcloud-player/pull/90)

I've tested a bunch on windows and I am currently using it on my steam deck without any issues. It's nice because it allows me to hold the button I've mapped to 'N' to pull up the power menu.

Let me know if you want me to make any changes.
