### PR TITLE
Autohide Menu for cleaner fullscreen closes #437

### DIFF
--- a/main/helpers/create-window.ts
+++ b/main/helpers/create-window.ts
@@ -76,6 +76,7 @@ export default (windowName: string, options: BrowserWindowConstructorOptions): B
       contextIsolation: false,
       ...options.webPreferences,
     },
+    autoHideMenuBar: true,
   };
   win = new BrowserWindow(browserOptions);
 


### PR DESCRIPTION
Resolving issues #437. Autohiding the electron menu makes fullscreen clean on windows. Menu can be accessed at anytime by pressing the 'Alt' key