### PR TITLE
Don't always rebuild xal-node if not necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "publish": "electron-builder -p onTag",
     "storybook": "start-storybook -p 6006 -s ./renderer/public",
     "build-storybook": "build-storybook",
-    "build-deps": "cd xal-node && npm ci"
+    "build-deps": "cd xal-node/dist || npm run rebuild-deps",
+    "rebuild-deps": "cd xal-node && echo npm ci"
   },
   "dependencies": {
     "axios": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "storybook": "start-storybook -p 6006 -s ./renderer/public",
     "build-storybook": "build-storybook",
     "build-deps": "cd xal-node/dist || npm run rebuild-deps",
-    "rebuild-deps": "cd xal-node && echo npm ci"
+    "rebuild-deps": "cd xal-node && npm ci"
   },
   "dependencies": {
     "axios": "^1.3.4",


### PR DESCRIPTION
The project depends on `xal-node` which has a build script like

```
{
  ...
  "scripts": {
    "build": "rm -rf dist/ && tsc && cargo-cp-artifact -nc dist/xal-node.node -- cargo build --message-format=json-render-diagnostics",
 ...
```

which is fine in the context of `xal-node` itself, but annoying in the context of Greenlight. When fiddling with the codebase and running `npm run dev` I always have to wait for the darn thing to get rebuilt.

In order to mitigate this I added a `rebuild-deps` script.

Now, when I run `npm run dev` or `npm run build` I don't have to wait ages for the build.
If anything changes in `xal-node` I need to run `npm run rebuild-deps` tho' which is a bummer.
An idea for a solution: not sure if there's such a thing, but when a "submodule is updated" the `./dist` could be deleted or something. Not sure if this is needed, but let me know, I can take a look (seems quirky).
