### PR TITLE
Fix app not closing on Windows

### DIFF
--- a/main/background.ts
+++ b/main/background.ts
@@ -112,6 +112,8 @@ export default class Application {
     this._mainWindow.on('close', (event) => {
       if(this._isQuitting) {
         this._mainWindow = null
+      } else if (process.platform === 'win32') {
+        app.quit()
       } else {
         event.preventDefault()
         this._mainWindow.hide()


### PR DESCRIPTION
Fix that makes the close X button in the upper-right corner of the window on Windows would not terminate all processes in the background. Clicking the Xbox logo button would.

My fix is just a simple bandage. Ideally clicking the OS's close button would popup a confirm window as with the Xbox logo button, but I can live with this (if everyone else could live with it up to this point then this is a small scale problem).

For me it's a problem, because I hit <kbd>Alt+F4</kbd> by habit, which does the same as clicking the OS close button.

Let me if know if this isn't acceptable and something more novel should be in place.