### PR TITLE
Add instructions for workaround to allow launching from Steam Deck UI to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ The application also provides a way to see which of your friends are online. Thi
 
 ## Steam Deck Setup
 
-This application is reported to be working on the Steam Deck with some small bugs and side-effects. You can map one of the Steam Deck back buttons to the 'N' key to simulate the Xbox button.
+This application is reported to be working on the Steam Deck with some small bugs and side-effects. You can map one of the Steam Deck back buttons to the 'N' key to simulate the Xbox button. 
+
+Some users have reported being unable to launch Greenlight from the Steam Deck UI (being stuck in an endless loading screen that requires rebooting the system). To prevent this, add `LD_PRELOAD= %command%` to the launch arguments, listed before any other launch arguments. 
 
 ### Optional launch arguments
 


### PR DESCRIPTION
There is an issue in the v2 beta that prevents Steam Deck users from launching Greenlight while in the Steam Deck UI (formerly known as Big Picture).

Including launch argument `LD_PRELOAD= %command%` appears to resolve the issue. It's not clear to me why, as no custom library is referenced, but can confirm this works (source #718).  Alternatively, installing the appimage with AppImageInstaller was suggested as a solution in #853 - I have not verified this works but that may be worth adding as a workaround, or as _the_ recommended usage instructions. 

The bug preventing this from launching on Steam Deck could still be fixed in a future release, as this software is very popular for Deck owners (ideally, the install process should be simplified by making the software available on Steam - or in KDE discover), but in the meantime, this repo should have all necessary instructions necessary to launch it on the device.