### PR TITLE
device info updated to stream true 1080p feed from xCloud

### DIFF
--- a/main/helpers/xcloudapi.ts
+++ b/main/helpers/xcloudapi.ts
@@ -170,20 +170,21 @@ export default class xCloudApi {
                     "clientAppId": "Microsoft.GamingApp",
                     "clientAppType": "native",
                     "clientAppVersion": "2203.1001.4.0",
-                    "clientSdkVersion": "5.3.0",
+                    "clientSdkVersion": "8.5.2",
                     "httpEnvironment": "prod",
                     "sdkInstallId": ""
                 }
             },
             "dev": {
                 "hw": {
-                    "make": "Micro-Star International Co., Ltd.",
-                    "model": "GS66 Stealth 10SGS",
+                    "make": "Microsoft",
+                    "model": "Surface Pro",
                     "sdktype": "native"
                 },
                 "os": {
-                    "name": "Windows 10 Pro",
-                    "ver": "19041.1.amd64fre.vb_release.191206-1406"
+                    "name": "Windows 11",
+                    "ver": "22631.2715",
+                    "platform": "desktop"
                 },
                 "displayInfo": {
                     "dimensions": {


### PR DESCRIPTION
This is a follow up on the discussion I started to add support for 1080P from xCloud & 'local' Xbox streaming. Turns out the Xbox App Remote Beta version supports 1080p stream. Furthermore, on desktop, 1080p stream is supported. I have verified it via Edge Inspect tool on 'media' This PR should nudge us towards the right direction to have support for 1080p.

Discussion: https://github.com/unknownskl/greenlight/discussions/1050

Reference: https://github.com/redphx/better-xcloud/blob/5f18026f85c666cfbdcbc9d8ce194136db1fcff1/better-xcloud.user.js#L5395