### PR TITLE
Keyboard mapping configurability

### DIFF
--- a/renderer/context/userContext.defaults.ts
+++ b/renderer/context/userContext.defaults.ts
@@ -8,6 +8,7 @@ export const defaultSettings = {
     force_region_ip: '',
     input_touch: false,
     input_mousekeyboard: false,
+    input_mousekeyboard_config: undefined,
     input_newgamepad: false,
     app_lowresolution: false,
 

--- a/renderer/pages/settings/input.tsx
+++ b/renderer/pages/settings/input.tsx
@@ -5,11 +5,66 @@ import SettingsSidebar from '../../components/settings/sidebar'
 import Card from '../../components/ui/card'
 
 import { useSettings } from '../../context/userContext'
+import {InputFrame} from 'xbox-xcloud-player/dist/Channel/Input'
 
+const emptyInputFrame = () => ({
+    GamepadIndex: 0,
+    Nexus: 0,
+    Menu: 0,
+    View: 0,
+    A: 0,
+    B: 0,
+    X: 0,
+    Y: 0,
+    DPadUp: 0,
+    DPadDown: 0,
+    DPadLeft: 0,
+    DPadRight: 0,
+    LeftShoulder: 0,
+    RightShoulder: 0,
+    LeftThumb: 0,
+    RightThumb: 0,
+
+    LeftThumbXAxis: 0.0,
+    LeftThumbYAxis: 0.0,
+    RightThumbXAxis: 0.0,
+    RightThumbYAxis: 0.0,
+    LeftTrigger: 0.0,
+    RightTrigger: 0.0,
+}) as InputFrame
+
+function invert(dict) {
+    const inv = {}
+    for(const [k, v] of Object.entries(dict)) {
+        inv[v.toString()] = k
+    }
+    return inv
+}
+
+function KeySettings({keyConfigs, setKeyConfig}) {
+    const keys = Object.keys(emptyInputFrame())
+    keyConfigs = invert(keyConfigs)
+    return <p>
+        {
+            keys.map(
+                (btn: keyof InputFrame) =>(
+                    <p key={btn}>
+                        <label>{btn}</label>
+                        <label style={{minWidth: 0}}>
+                            <input type='text' className='text' onKeyUp={(e) => setKeyConfig(btn, e.key)} value={keyConfigs[btn] ?? 'None'}/>
+                        </label>
+                    </p>
+                )
+            )
+        }
+    </p>
+}
 
 function SettingsInput() {
     const { settings, setSettings} = useSettings()
     const [ controllerPing, setControllerPing] = React.useState(0)
+
+    const [controllerKeys, setControllerKeys] = React.useState(settings.input_mousekeyboard_config)
 
     React.useEffect(() => {
         console.log('Last controller check:', controllerPing)
@@ -50,6 +105,28 @@ function SettingsInput() {
         })
     }
 
+    function setKeyConfig(button: keyof InputFrame, keymap: string) {
+        let ckeys = controllerKeys
+        if(ckeys === undefined) {
+            ckeys = {}
+        }
+
+
+        for (const ckeysKey of Object.keys(ckeys)) {
+            if(ckeys[ckeysKey] === button) delete ckeys[ckeysKey]
+        }
+
+        if (keymap !== 'Backspace')
+            ckeys[keymap] = button
+
+        setControllerKeys(ckeys)
+
+        setSettings({
+            ...settings,
+            input_mousekeyboard_config: ckeys,
+        })
+    }
+
     return (
         <React.Fragment>
             <Head>
@@ -80,6 +157,10 @@ function SettingsInput() {
                             <input type='checkbox' onChange={ setMKBInput } checked={settings.input_mousekeyboard} />&nbsp; ({ settings.input_mousekeyboard ? 'Enabled' : 'Disabled'})
                         </label>
                     </p>
+
+                    {
+                        settings.input_mousekeyboard ? <KeySettings keyConfigs={controllerKeys} setKeyConfig={setKeyConfig}></KeySettings> : <></>
+                    }
 
                     <p>
                         <label>Enable new Gamepad driver</label>

--- a/renderer/pages/stream/[serverid].tsx
+++ b/renderer/pages/stream/[serverid].tsx
@@ -174,6 +174,9 @@ function Stream() {
                                 input_touch: settings.input_touch || false,
                                 input_mousekeyboard: settings.input_mousekeyboard || false,
                                 input_legacykeyboard: (settings.input_newgamepad) ? false : true,
+                                input_mousekeyboard_config: settings.input_mousekeyboard_config !== undefined ? {
+                                    _keymapping: settings.input_mousekeyboard_config,
+                                } : undefined,
                             }))
                             break
 


### PR DESCRIPTION
This PR allows for keyboard mappings to be configured from the settings page.

Nice to haves: Find out how to configure mouse inputs.

Depends-On: https://github.com/unknownskl/xbox-xcloud-player/pull/271