### PR TITLE
Change flags to enable VA-API

### DIFF
--- a/main/application.ts
+++ b/main/application.ts
@@ -41,14 +41,17 @@ export default class Application {
         console.log(__filename+'[constructor()] Starting Greenlight v'+pkg.version)
         this._log = Debug('greenlight')
 
-        ElectronApp.commandLine.appendSwitch('enable-features', 'VaapiIgnoreDriverChecks,VaapiVideoDecoder,PlatformHEVCDecoderSupport,CanvasOopRasterization')
-        // ElectronApp.commandLine.appendSwitch('disable-features', 'UseChromeOSDirectVideoDecoder');
+        ElectronApp.commandLine.appendSwitch('use-vulkan')
+        ElectronApp.commandLine.appendSwitch('use-angle', 'vulkan')
+        ElectronApp.commandLine.appendSwitch('enable-features', 'Vulkan,VulkanFromANGLE,DefaultANGLEVulkan,VaapiIgnoreDriverChecks,VaapiVideoDecoder,PlatformHEVCDecoderSupport,CanvasOopRasterization')
+        ElectronApp.commandLine.appendSwitch('disable-features', 'UseChromeOSDirectVideoDecoder');
         ElectronApp.commandLine.appendSwitch('enable-gpu-rasterization')
         ElectronApp.commandLine.appendSwitch('enable-oop-rasterization')
-        ElectronApp.commandLine.appendSwitch('accelerated-video-decode')
+        ElectronApp.commandLine.appendSwitch('enable-accelerated-video-decode')
         ElectronApp.commandLine.appendSwitch('ozone-platform-hint', 'x11')
         ElectronApp.commandLine.appendSwitch('ignore-gpu-blocklist')
-        // ElectronApp.commandLine.appendSwitch('enable-zero-copy');
+        ElectronApp.commandLine.appendSwitch('no-sandbox');
+        ElectronApp.commandLine.appendSwitch('enable-zero-copy');
 
         this.readStartupFlags()
         this.loadApplicationDefaults()


### PR DESCRIPTION
Modify Electron flags to enable VA-API this has led to about 10% less usage on Steam Deck.

Changes include using Vulkan and enabling some flags that hopefully enable VA-API and use hardware decoding.