### PR TITLE
fix(authentication): improve silent flow region handling and token refresh logic

### DIFF
--- a/packages/desktop/main/authentication.ts
+++ b/packages/desktop/main/authentication.ts
@@ -10,7 +10,7 @@ export default class Authentication {
 
     _tokenStore:AuthTokenStore
     _xal:Xal
-    
+
     _authWindow
     _authCallback
 
@@ -40,7 +40,7 @@ export default class Authentication {
                 this.startSilentFlow()
 
                 return true
-    
+
             } else {
                 this._application.log('authenticationV2', '[checkAuthentication()] No tokens are present.')
                 return false
@@ -51,6 +51,15 @@ export default class Authentication {
     startSilentFlow(){
         this._application.log('authenticationV2', '[startSilentFlow()] Starting silent flow...')
         this._isAuthenticating = true
+
+        // Force region spoofing if set
+        const forceRegionIp = this._application._store.get('force_region_ip', '')
+        if (forceRegionIp && typeof forceRegionIp === 'string' && forceRegionIp.trim() !== '') {
+            this._xal.setDefaultHeaders({ 'X-Forwarded-For': forceRegionIp.trim() })
+            this._application.log('authenticationV2', '[startSilentFlow()] Using X-Forwarded-For:', forceRegionIp)
+        } else {
+            this._xal.setDefaultHeaders({})
+        }
 
         this._xal.refreshTokens().then(() => {
             this._application.log('authenticationV2', '[startSilentFlow()] Tokens have been refreshed')
@@ -66,7 +75,7 @@ export default class Authentication {
 
                 this._xal.getWebToken().then((webToken) => {
                     this._application.log('authenticationV2', __filename+'[startSilentFlow()] Web token received')
-                    
+
                     this._application.authenticationCompleted(streamingTokens, webToken)
 
                 }).catch((error) => {
@@ -93,7 +102,7 @@ export default class Authentication {
 
     startAuthflow(){
         this._application.log('authenticationV2', '[startAuthflow()] Starting authentication flow')
-        
+
         this._xal.getRedirectUri().then((redirect) => {
             this.openAuthWindow(redirect.sisuAuth.MsaOauthRedirect)
 
@@ -149,7 +158,7 @@ export default class Authentication {
             height: 600,
             title: 'Authentication',
         })
-        
+
         authWindow.loadURL(url)
         this._authWindow = authWindow
 
@@ -185,5 +194,5 @@ export default class Authentication {
         return { xHomeToken: this._xal._xhomeToken, xCloudToken: this._xal._xcloudToken }
     }
 
-    
+
 }

--- a/packages/desktop/main/ipc/app.ts
+++ b/packages/desktop/main/ipc/app.ts
@@ -61,7 +61,7 @@ export default class IpcApp extends IpcBase {
             }, 100)
         })
     }
-    
+
     restart(){
         return new Promise<boolean>((resolve) => {
             resolve(true)
@@ -107,7 +107,7 @@ export default class IpcApp extends IpcBase {
                 autoStream: this._application.getStartupFlags().autoStream,
             })
             this._application.getStartupFlags().autoStream = ''
-        }) 
+        })
     }
 
     setForceRegionIp(args:setForceRegionIpArgs){
@@ -115,8 +115,14 @@ export default class IpcApp extends IpcBase {
             console.log('IPC received force region IP data and write to store:', args.ip)
             this._application._store.set('force_region_ip', args.ip)
 
-            // Rerun silent flow to retrieve new tokens
-            this._application._authentication.startSilentFlow()
+            // Recreate Xal instance to reset all internal state and connections
+            const { _authentication } = this._application
+            const { _tokenStore } = _authentication
+            const { Xal } = require('xal-node')
+            _authentication._xal = new Xal(_tokenStore)
+
+            // Rerun silent flow to retrieve new tokens with new region
+            _authentication.startSilentFlow()
 
             resolve(true)
         })


### PR DESCRIPTION
This pull request introduces enhancements to the region spoofing feature in the authentication flow of the desktop application. The main improvements ensure that when a forced region IP is set, the authentication process uses the correct headers and resets internal authentication state to reflect the change.

Authentication flow improvements:

* In `authentication.ts`, the `startSilentFlow` method now checks for a `force_region_ip` value in the application store. If present, it sets the `X-Forwarded-For` header accordingly to spoof the region; otherwise, it clears any custom headers. This ensures the authentication requests use the intended region.

Region spoofing state management:

* In `ipc/app.ts`, when a new force region IP is received via IPC, the code now recreates the `Xal` instance to reset all internal state and connections before restarting the silent authentication flow. This guarantees that the new region setting is fully applied for subsequent authentication requests.