### PR TITLE
feat(i18n): Implement language context and internationalization support

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,17 @@
     "logger": "yarn workspace @greenlight/logger",
     "platform": "yarn workspace @greenlight/platform",
     "server": "yarn workspace @greenlight/server",
-
     "test": "yarn logger test"
   },
   "workspaces": [
     "packages/desktop",
     "packages/docs"
   ],
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
+  "dependencies": {
+    "@types/i18next": "^12.1.0",
+    "@types/react-i18next": "^7.8.3",
+    "i18next": "^25.5.2",
+    "react-i18next": "^15.7.3"
+  }
 }

--- a/packages/desktop/main/application.ts
+++ b/packages/desktop/main/application.ts
@@ -12,6 +12,8 @@ import xCloudApi from './helpers/xcloudapi'
 
 import pkg from '../package.json'
 
+import i18n from 'i18next';
+
 interface startupFlags {
     fullscreen:boolean;
     autoStream:string;
@@ -37,6 +39,8 @@ export default class Application {
     public _webUI:WebUI
     public _authentication:Authentication
 
+    private t = i18n.t.bind(i18n);
+
     constructor(){
         console.log(__filename+'[constructor()] Starting Greenlight v'+pkg.version)
         this._log = Debug('greenlight')
@@ -57,7 +61,7 @@ export default class Application {
         this.loadApplicationDefaults()
 
         // ElectronApp.removeAsDefaultProtocolClient('ms-xal-public-beta-000000004c20a908')
-        
+
         this._ipc = new Ipc(this)
         this._authentication = new Authentication(this)
 
@@ -110,7 +114,7 @@ export default class Application {
 
             serve({ directory: 'app' })
         } else {
-            
+
             ElectronApp.setPath('userData', `${ElectronApp.getPath('userData')} (development)`)
         }
 
@@ -125,7 +129,7 @@ export default class Application {
 
             this.openMainWindow()
             this._authentication.startWebviewHooks()
-        
+
             // Check authentication
             if(! this._authentication.checkAuthentication()){
                 this._authentication.startAuthflow()
@@ -134,7 +138,7 @@ export default class Application {
         }).catch((error) => {
             this.log('electron', __filename+'[loadApplicationDefaults()] Electron has failed to load:', error)
         })
-          
+
         ElectronApp.on('window-all-closed', () => {
             if(this._isMac === true){
                 this.log('electron', __filename+'[loadApplicationDefaults()] Electron detected that all windows are closed. Running in background...')
@@ -146,7 +150,7 @@ export default class Application {
         })
 
         ElectronApp.on('activate', () => {
-            (this._mainWindow !== undefined) ? this._mainWindow.show() : this.openMainWindow() 
+            (this._mainWindow !== undefined) ? this._mainWindow.show() : this.openMainWindow()
         })
         ElectronApp.on('before-quit', () => this._isQuitting = true)
     }
@@ -196,7 +200,7 @@ export default class Application {
         }).catch((error) => {
             this.log('electron', __filename+'[authenticationCompleted()] Failed to retrieve user profile:', error)
             dialog.showMessageBox({
-                message: 'Error: Failed to retrieve user profile:'+ JSON.stringify(error),
+                message: this.t('errors.failedToRetrieveUserProfile') + JSON.stringify(error),
                 type: 'error',
             })
         })
@@ -239,7 +243,7 @@ export default class Application {
         } else {
             const port = process.argv[2] || 3000
             this._mainWindow.loadURL(`http://localhost:${port}/home`)
-            
+
             if(this._isCi !== true){
                 this._mainWindow.webContents.openDevTools()
                 this.openGPUWindow()

--- a/packages/desktop/main/authentication.ts
+++ b/packages/desktop/main/authentication.ts
@@ -3,6 +3,7 @@ import { createWindow } from './helpers'
 import Application from './application'
 import { Xal } from 'xal-node'
 import AuthTokenStore from './helpers/tokenstore'
+import i18n from 'i18next';
 
 
 export default class Authentication {
@@ -17,6 +18,8 @@ export default class Authentication {
     _isAuthenticating:boolean = false
     _isAuthenticated:boolean = false
     _appLevel:number = 0
+
+    private t = i18n.t.bind(i18n);
 
     constructor(application:Application){
         this._application = application
@@ -81,7 +84,7 @@ export default class Authentication {
                 }).catch((error) => {
                     this._application.log('authenticationV2', __filename+'[startSilentFlow()] Failed to retrieve web tokens:', error)
                     dialog.showMessageBox({
-                        message: 'Error: Failed to retrieve web tokens:'+ JSON.stringify(error),
+                        message: this.t('errors.failedToRetrieveWebTokens') + ' ' + JSON.stringify(error),
                         type: 'error',
                     })
                 })
@@ -89,7 +92,7 @@ export default class Authentication {
             }).catch((err) => {
                 this._application.log('authenticationV2', '[startSilentFlow()] Failed to retrieve streaming tokens:', err)
                 dialog.showMessageBox({
-                    message: 'Error: Failed to retrieve streaming tokens:'+ JSON.stringify(err),
+                    message: this.t('errors.failedToRetrieveStreamingTokens') + ' ' + JSON.stringify(err),
                     type: 'error',
                 })
             })
@@ -119,12 +122,12 @@ export default class Authentication {
 
                 }).catch((err) => {
                     this._application.log('authenticationV2', '[startAuthFlow()] Error authenticating user:', err)
-                    dialog.showErrorBox('Error', 'Error authenticating user. Error details: '+JSON.stringify(err))
+                    dialog.showErrorBox('Error', this.t('errors.errorAuthentificationUser') + ' ' + JSON.stringify(err))
                 })
             }
         }).catch((err) => {
             this._application.log('authenticationV2', '[startAuthFlow()] Error getting redirect URI:', err)
-            dialog.showErrorBox('Error', 'Error getting redirect URI. Error details: '+JSON.stringify(err))
+            dialog.showErrorBox('Error', this.t('errors.errorGettingRedirectURI') + ' ' + JSON.stringify(err))
         })
     }
 
@@ -146,7 +149,7 @@ export default class Authentication {
                     this._authCallback(details.responseHeaders.Location[0])
                 } else {
                     this._application.log('authenticationV2', '[startWebviewHooks()] Authentication Callback is not defined:', this._authCallback)
-                    dialog.showErrorBox('Error', 'Authentication Callback is not defined. Error details: '+JSON.stringify(this._authCallback))
+                    dialog.showErrorBox('Error', this.t('errors.authentificationCallbackIsNotDefined') + ' ' + JSON.stringify(this._authCallback))
                 }
 
                 callback({ cancel: true })
@@ -160,7 +163,7 @@ export default class Authentication {
         const authWindow = createWindow('auth', {
             width: 500,
             height: 600,
-            title: 'Authentication',
+            title: this.t('auth.windowTitle'),
         })
 
         authWindow.loadURL(url)
@@ -175,7 +178,7 @@ export default class Authentication {
     async getStreamingToken(){
         const sisuToken = this._tokenStore.getSisuToken()
         if(sisuToken === undefined)
-            throw new Error('Sisu token is missing. Please authenticate first')
+            throw new Error( this.t('errors.sisuTokenIsMissing') )
 
         const xstsToken = await this._xal.doXstsAuthorization(sisuToken, 'http://gssv.xboxlive.com/')
 

--- a/packages/desktop/main/helpers/updater.ts
+++ b/packages/desktop/main/helpers/updater.ts
@@ -3,6 +3,7 @@ import electron from 'electron'
 import { compare } from 'compare-versions'
 import gh from 'github-url-to-object'
 import pkg from '../../package.json'
+import i18n from 'i18next'
 
 // Base code below from https://github.com/ankurk91/electron-update-notifier. Credits to @ankurk91.
 
@@ -19,6 +20,8 @@ interface GithubReleaseObject {
   body: string;
   html_url: string;
 }
+
+const t = i18n.t.bind(i18n)
 
 export const defaultOptions: Options = {
     debug: false, // force run in development
@@ -50,7 +53,7 @@ export async function checkForUpdates({repository, token, debug, silent, prerele
         const ghObj = gh(pkg.repository)
 
         if (!ghObj) {
-            throw new Error('Repository URL not found in package.json file.')
+            throw new Error(t('errors.repositoryNotFound'))
         }
 
         repository = ghObj.user + '/' + ghObj.repo
@@ -72,13 +75,13 @@ export async function checkForUpdates({repository, token, debug, silent, prerele
                 break
             }
         }
-    
+
     } catch (error) {
         console.error(error)
         logger.log('updater', __filename+'[checkForUpdates()] Error while checking for updates:', error)
 
         if (!silent) {
-            showDialog('Unable to check for updates at this moment. Try again.', 'error')
+            showDialog(t('updater.unableToCheckForUpdates'), 'error')
         }
     }
 
@@ -90,7 +93,7 @@ export async function checkForUpdates({repository, token, debug, silent, prerele
     } else {
         logger.log('updater', __filename+'[checkForUpdates()] Application is newest version. Current version:', electron.app.getVersion(), 'Newest version:', latestRelease.tag_name )
         if (!silent) {
-            showDialog(`You are already running the latest version. Current version: ${electron.app.getVersion()}. Newest version: ${latestRelease.tag_name}`)
+            showDialog(t('updater.alreadyOnLatestVersion') + electron.app.getVersion() + ". " + t('updater.newestVersion') + " " + latestRelease.tag_name)
         }
     }
 }
@@ -100,9 +103,9 @@ export function showUpdateDialog(release: GithubReleaseObject) {
         {
             title: electron.app.getName(),
             type: 'info',
-            message: 'New release available',
-            detail: `Installed Version: ${electron.app.getVersion()}\nLatest Version: ${release.tag_name}\n\n${release.body}`.trim(),
-            buttons: ['Download', 'Later'],
+            message: t('updater.newReleaseAvailable'),
+            detail: `${t('updater.installedVersion')} ${electron.app.getVersion()}\n${t('updater.latestVersion')} ${release.tag_name}\n\n${release.body}`.trim(),
+            buttons: [t('updater.downloadBtn'), t('updater.laterBtn')],
             defaultId: 0,
             cancelId: 1,
         },
@@ -123,8 +126,8 @@ const showDialog = (detail: string, type: string = 'info') => {
     electron.dialog.showMessageBox(
         {
             title: electron.app.getName(),
-            message: 'Update checker',
-            buttons: ['Close'],
+            message: t('updater.updateChecker'),
+            buttons: [t('updater.closeBtn')],
             defaultId: 0,
             cancelId: 0,
             type,

--- a/packages/desktop/renderer/components/auth.tsx
+++ b/packages/desktop/renderer/components/auth.tsx
@@ -6,6 +6,8 @@ import Card from '../components/ui/card'
 import Button from './ui/button'
 import Loader from './ui/loader'
 
+import { useTranslation } from 'react-i18next'
+
 interface AuthProps {
   signedIn: boolean;
   gamertag?: string;
@@ -21,29 +23,30 @@ function Auth({
     gamerscore,
     isLoading = false,
 }: AuthProps) {
+    const { t } = useTranslation()
 
     function startAuthFlow(){
         Ipc.send('app', 'login')
     }
 
     function logout(){
-        if(confirm('Are you sure you want to logout?')){
+        if(confirm(t('auth.logoutQuestion'))){
             Ipc.send('app', 'clearData')
         }
     }
 
     function clearData(){
-        if(confirm('This will remove all application data, which is sometimes helpful when you are stuck in a login loop. Do you want to continue?')){
+        if(confirm(t('auth.clearDataQuestion'))){
             Ipc.send('app', 'clearData')
         }
     }
-  
+
     return (
         <React.Fragment>
             <div id="component_auth">
 
                 <div id="component_auth_modal">
-                    { isLoading === false ? 
+                    { isLoading === false ?
                         <Card>
                             {signedIn === true ? (<div className="component_auth_profile_container">
                                 <div className="component_auth_profile_gamerpic">
@@ -53,16 +56,16 @@ function Auth({
                                 <div className="component_auth_profile_userdetails">
                                     <h1>{ gamertag }</h1>
                                     <p>
-                      Gamerscore: { gamerscore }
+                                        {t('auth.gamerscore')}: { gamerscore }
                                     </p>
                                     {/* <p>
-                      { 'Logging in...' }
-                    </p> */}
-                                    <Button label="Login" className='btn-primary' onClick={ () => {
-                                        startAuthFlow() 
+                                        {t('auth.loggingIn')}
+                                    </p> */}
+                                    <Button label={t('auth.loginBtn')} className='btn-primary' onClick={ () => {
+                                        startAuthFlow()
                                     } }></Button> &nbsp;
-                                    <Button label="Logout" className='btn' onClick={ () => {
-                                        logout() 
+                                    <Button label={t('auth.logoutBtn')} className='btn' onClick={ () => {
+                                        logout()
                                     } }></Button>
                                 </div>
 
@@ -70,17 +73,15 @@ function Auth({
                                 textAlign: 'center',
                                 paddingBottom: '20px',
                             }}>
-                                <h1>Login with Xbox</h1>
-                  
+                                <h1>{t('auth.loginWithXbox')}</h1>
                                 <p>
-                    Please authenticate below to access xCloud and xHome Streaming
+                                    {t('auth.pleaseAuthenticate')}
                                 </p>
-
-                                <Button label="Login" className='btn-primary' onClick={ () => {
-                                    startAuthFlow() 
+                                <Button label={t('auth.loginBtn')} className='btn-primary' onClick={ () => {
+                                    startAuthFlow()
                                 } }></Button> &nbsp;
-                                <Button label="Clear data" className='btn' onClick={ () => {
-                                    clearData() 
+                                <Button label={t('auth.clearDataBtn')} className='btn' onClick={ () => {
+                                    clearData()
                                 } }></Button>
                             </div>) }
                         </Card>:<Card><div style={{

--- a/packages/desktop/renderer/components/header.tsx
+++ b/packages/desktop/renderer/components/header.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Link from 'next/link'
 import Ipc from '../lib/ipc'
+import { useTranslation } from 'react-i18next'
 
 // import { ipcRenderer } from 'electron'
 
@@ -15,20 +16,22 @@ function Header({
     gamertag,
     level = 0,
 }: HeaderProps) {
+    const { t } = useTranslation()
 
     // console.log('level:', level)
-    const [headerLinks, setHeaderLinks] = React.useState([])
+    const [activeIndex, setActiveIndex] = React.useState(0);
+    const [headerLinks, setHeaderLinks] = React.useState([]);
 
     function createLinks(level){
         return (level > 1) ? [
             {
-                name: 'My Consoles',
-                title: 'View consoles',
+                name: t('header.myConsoles'),
+                title: t('header.viewConsoles'),
                 url: '/home',
                 active: false,
             }, {
-                name: 'xCloud Library',
-                title: 'Browse xCloud library',
+                name: t('header.xCloudLibrary'),
+                title: t('header.browseXCloudLibrary'),
                 url: '/xcloud/home',
                 active: false,
                 // },{
@@ -36,30 +39,30 @@ function Header({
                 //   title: 'Debug page',
                 //   url: '/debug'
             }, {
-                name: 'Settings',
-                title: 'Change application settings',
+                name: t('header.settings'),
+                title: t('header.changeSettings'),
                 url: '/settings/home',
                 active: false,
             }, {
                 name: gamertag,
-                title: 'View profile',
+                title: t('header.viewProfile'),
                 url: '/profile',
                 active: false,
             },
         ] : [
             {
-                name: 'My Consoles',
-                title: 'View consoles',
+                name: t('header.myConsoles'),
+                title: t('header.viewConsoles'),
                 url: '/home',
                 active: false,
             }, {
-                name: 'Settings',
-                title: 'Change application settings',
+                name: t('header.settings'),
+                title: t('header.changeSettings'),
                 url: '/settings/home',
                 active: false,
             }, {
                 name: gamertag,
-                title: 'View profile',
+                title: t('header.viewProfile'),
                 url: '/profile',
                 active: false,
             },
@@ -67,50 +70,39 @@ function Header({
     }
 
     function setMenuActive(id) {
-        const links = createLinks(level)
-        links[id].active = true
-
-        setHeaderLinks(links)
-        return null
+        setActiveIndex(id);
     }
 
     function drawMenu() {
-        const linksHtml = []
-
-        for(const link in headerLinks){
-            linksHtml.push(<li key={ link }>
-                <Link legacyBehavior href={ headerLinks[link].url } key={ headerLinks[link].url }>
-                    <a title={ headerLinks[link].title } onClick={ () => {
-                        setMenuActive(link)
-                    } } className={headerLinks[link].active === true ? 'active' : ''}>{ headerLinks[link].name }</a>
+        return headerLinks.map((link, idx) => (
+            <li key={idx}>
+                <Link legacyBehavior href={link.url} key={link.url}>
+                    <a title={link.title} onClick={() => setMenuActive(idx)} className={idx === activeIndex ? 'active' : ''}>{link.name}</a>
                 </Link>
-            </li>)
-        }
-
-        return linksHtml
+            </li>
+        ));
     }
 
     function confirmQuit() {
         if(window.Greenlight.isWebUI() === true)
             return
-    
-        if(confirm('Are you sure you want to quit?')){
+
+        if(confirm(t('header.quitQuestion'))){
             Ipc.send('app', 'quit')
         }
     }
 
     React.useEffect(() => {
-        if(headerLinks.length <= 0 && !isNaN(level)){
-            const links = createLinks(level)
-            links[0].active = true
-            setHeaderLinks(links)
+        if (!isNaN(level)) {
+            const links = createLinks(level).map((link, idx) => ({ ...link, active: idx === activeIndex }));
+            setHeaderLinks(links);
         }
-    })
-  
+    }, [level, t, activeIndex]);
+
     return (
         <React.Fragment>
             <div id="component_header" className={hidden === true ? 'disabled' : ''}>
-                <a onClick={ confirmQuit } id="actionBarLogo" title="Home">
+                <a onClick={ confirmQuit } id="actionBarLogo" title={t('header.home')}>
                     <i className="fa-brands fa-xbox"></i>
                 </a>
 

--- a/packages/desktop/renderer/components/settings/LanguageSelector.tsx
+++ b/packages/desktop/renderer/components/settings/LanguageSelector.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import Card from "../../components/ui/card";
+import { useTranslation } from "react-i18next";
+import { useLanguage } from "../../context/languageContext";
+import i18n from "../../lib/i18n";
+import { useSettings } from "../../context/userContext";
+
+// Language selector for settings page
+const LanguageSelector: React.FC = () => {
+  const { setLanguage } = useLanguage();
+  const { t } = useTranslation();
+  const { settings, setSettings } = useSettings();
+
+  // Get the list of available languages and their names from i18n resources
+  const resources = i18n.options.resources || {};
+  const availableLanguages = Object.keys(resources);
+
+  // Create an array of objects: { code, name }
+  const languageOptions = availableLanguages.map((langCode) => {
+    const translation = resources[langCode]?.translation;
+    const langName = translation && typeof translation === "object" ? translation["languageName"] : langCode;
+    return { code: langCode, name: langName };
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const lang = e.target.value;
+    setLanguage(lang);
+    i18n.changeLanguage(lang); // Apply language instantly
+    setSettings({ ...settings, language: lang });
+  };
+
+  return (
+    <Card>
+      <div
+        style={{ paddingBottom: 20, display: "flex", gap: 10, alignItems: "center", justifyContent: "space-between" }}
+      >
+        <label htmlFor="language-select">{t("settings.about.selectorSelectLanguage")}:</label>
+        <select id="language-select" value={settings.language || ""} onChange={handleChange}>
+          {languageOptions.map(({ code, name }) => (
+            <option key={code} value={code}>
+              {name}
+            </option>
+          ))}
+        </select>
+      </div>
+    </Card>
+  );
+};
+
+export default LanguageSelector;

--- a/packages/desktop/renderer/components/settings/sidebar.tsx
+++ b/packages/desktop/renderer/components/settings/sidebar.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Link from 'next/link'
 import {useRouter} from 'next/router'
+import { useTranslation } from 'react-i18next'
 
 interface SettingsSidebarProps {
   children: any;
@@ -10,18 +11,19 @@ function SettingsSidebar({
     children,
 }: SettingsSidebarProps) {
     const router = useRouter()
+    const { t } = useTranslation()
 
     return (
         <React.Fragment>
             <div id="component_settings_sidebar">
                 <div id="component_settings_sidebar_menu">
                     <ul>
-                        <li className={ router.pathname.includes('settings/home') ? 'active' : ''}><Link href="/settings/home">About</Link></li>
-                        <li className={ router.pathname.includes('settings/streaming') ? 'active' : ''}><Link href="/settings/streaming">Streaming</Link></li>
-                        <li className={ router.pathname.includes('settings/input') ? 'active' : ''}><Link href="/settings/input">Input</Link></li>
-                        <li className={ router.pathname.includes('settings/video') ? 'active' : ''}><Link href="/settings/video">Video & Audio</Link></li>
-                        <li className={ router.pathname.includes('settings/webui') ? 'active' : ''}><Link href="/settings/webui">Web UI</Link></li>
-                        <li className={ router.pathname.includes('settings/debug') ? 'active' : ''}><Link href="/settings/debug">Debug</Link></li>
+                        <li className={ router.pathname.includes('settings/home') ? 'active' : ''}><Link href="/settings/home">{t('settings.sidebar.about')}</Link></li>
+                        <li className={ router.pathname.includes('settings/streaming') ? 'active' : ''}><Link href="/settings/streaming">{t('settings.sidebar.streaming')}</Link></li>
+                        <li className={ router.pathname.includes('settings/input') ? 'active' : ''}><Link href="/settings/input">{t('settings.sidebar.input')}</Link></li>
+                        <li className={ router.pathname.includes('settings/video') ? 'active' : ''}><Link href="/settings/video">{t('settings.sidebar.videoAudio')}</Link></li>
+                        <li className={ router.pathname.includes('settings/webui') ? 'active' : ''}><Link href="/settings/webui">{t('settings.sidebar.webUI')}</Link></li>
+                        <li className={ router.pathname.includes('settings/debug') ? 'active' : ''}><Link href="/settings/debug">{t('settings.sidebar.debug')}</Link></li>
                     </ul>
                 </div>
 

--- a/packages/desktop/renderer/components/sidebar/friends.tsx
+++ b/packages/desktop/renderer/components/sidebar/friends.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import Ipc from '../../lib/ipc'
 import SidebarFriendItem from './frienditem'
+import { useTranslation } from 'react-i18next'
 
 function SidebarFriends() {
     const [onlineFriends, setOnlineFriends] = React.useState([])
+    const { t } = useTranslation()
 
     React.useEffect(() => {
 
@@ -13,13 +15,13 @@ function SidebarFriends() {
             })
         }
         setTimeout(() => {
-            updateFriends() 
+            updateFriends()
         }, 1000)
         setTimeout(() => {
-            updateFriends() 
+            updateFriends()
         }, 2000)
         setTimeout(() => {
-            updateFriends() 
+            updateFriends()
         }, 3000)
         const friendsInterval = setInterval(updateFriends, 1000*15)
 
@@ -27,15 +29,15 @@ function SidebarFriends() {
             clearInterval(friendsInterval)
         }
     }, [])
-  
+
     return (
         <React.Fragment>
             <div id="components_sidebarfriends" key="components_sidebarfriends">
-                {(onlineFriends.length > 0) ? onlineFriends.map((item:any) => {               
+                {(onlineFriends.length > 0) ? onlineFriends.map((item:any) => {
                     return (
                         <SidebarFriendItem key={ item.xuid } userinfo={ item }></SidebarFriendItem>
-                    ) 
-                }) : <div className='components_sidebarfrienditem'><div className='components_sidebarfrienditem_userdetails'><p>All your friends are offline</p></div></div> }
+                    )
+                }) : <div className='components_sidebarfrienditem'><div className='components_sidebarfrienditem_userdetails'><p>{t('friends.allFriendsOffline')}</p></div></div> }
             </div>
         </React.Fragment>
     )

--- a/packages/desktop/renderer/components/ui/game/title.tsx
+++ b/packages/desktop/renderer/components/ui/game/title.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
+import { useTranslation } from 'react-i18next'
 
 interface GameTitleProps {
     name: string;
@@ -13,6 +14,7 @@ function GameTitle({
     src,
     titleId,
 }: GameTitleProps) {
+    const { t } = useTranslation()
     // const [clientHeight, setClientHeight] = React.useState(0);
 
     React.useEffect(() => {
@@ -27,7 +29,7 @@ function GameTitle({
         <React.Fragment>
             <div className='component_gametitle'>
                 <div className='component_gametitle_infopage'>
-                    <Link href={ '/xcloud/info/'+titleId } title='View game page'><i className="fa-solid fa-info" /></Link>
+                    <Link href={ '/xcloud/info/'+titleId } title={t("page.xCloudLibrary.viewGamePageIcon")}><i className="fa-solid fa-info" /></Link>
                 </div>
 
                 <Link href={ `/stream/xcloud_${ titleId }` }>

--- a/packages/desktop/renderer/components/ui/game/titledynamic.tsx
+++ b/packages/desktop/renderer/components/ui/game/titledynamic.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image'
 import Ipc from '../../../lib/ipc'
 import Loader from '../loader'
 import { useQuery } from 'react-query'
+import { useTranslation } from 'react-i18next'
 
 interface GameTitleProps {
     titleId: string;
@@ -23,17 +24,18 @@ function GameTitleDynamic({
     titleId,
 }: GameTitleProps) {
     const titleData = useQuery<titleDataState>('titledynamic_titleId_'+titleId, () => Ipc.send('xCloud', 'getTitle', { titleId: titleId }), { staleTime: 300*1000 })
+    const { t } = useTranslation()
 
     return (
         <React.Fragment>
             <div className='component_gametitle'>
                 <div className='component_gametitle_infopage'>
-                    <Link href={ '/xcloud/info/'+titleId } title='View game page'><i className="fa-solid fa-info" /></Link>
+                    <Link href={ '/xcloud/info/'+titleId } title={t("page.xCloudLibrary.viewGamePageIcon")}><i className="fa-solid fa-info" /></Link>
                 </div>
 
                 { (titleData.isFetched === true && titleData.data.titleId !== undefined) ? <Link href={ `/stream/xcloud_${ titleId }` }>
 
-                    <Image 
+                    <Image
                         src={ 'https:'+titleData.data.catalogDetails.Image_Tile?.URL }
                         alt={ titleData.data.catalogDetails.ProductTitle }
                         width='280' height='280' style={{

--- a/packages/desktop/renderer/components/ui/streamcomponent.tsx
+++ b/packages/desktop/renderer/components/ui/streamcomponent.tsx
@@ -6,6 +6,7 @@ import Loader from './loader'
 import Card from './card'
 import uPlot from 'uplot'
 import Ipc from '../../lib/ipc'
+import { useTranslation } from 'react-i18next'
 
 interface StreamComponentProps {
     onDisconnect?: () => void;
@@ -18,6 +19,7 @@ function StreamComponent({
     onMenu,
     xPlayer,
 }: StreamComponentProps) {
+    const { t } = useTranslation()
 
     function performance_now_seconds() {
         return performance.now() / 1000.0
@@ -29,11 +31,11 @@ function StreamComponent({
     let webRtcStatsInterval
 
     const [micStatus, setMicStatus] = React.useState(false)
-    const [waitingSeconds, setWaitingSeconds] = React.useState(0)  
+    const [waitingSeconds, setWaitingSeconds] = React.useState(0)
 
 
 
-    //Client-side volume control 
+    //Client-side volume control
     const [volume, setVolume] = React.useState(1.0) //without any controls, the volume has been maxed by default, let's follow this assumption and start at full for our slider
     const handleVolumeChange = (newVolume: number) => {
 
@@ -284,7 +286,7 @@ function StreamComponent({
     }
 
     function endStream() {
-        if (confirm('Are you sure you want to end your stream?')) {
+        if (confirm(t("streamWindow.endStreamConfirmMessage"))) {
             document.getElementById('streamComponentHolder').innerHTML = ''
             onDisconnect()
             xPlayer.close()
@@ -308,7 +310,7 @@ function StreamComponent({
             setWaitingSeconds(seconds)
 
             const formattedWaitingTime = formatWaitingTime(seconds)
-            const html = '<div>Estimated waiting time in queue: <span id="component_streamcomponent_waitingtimes_seconds">' + formattedWaitingTime + '</span></div>'
+            const html = '<div>' + t("streamWindow.estimatedWaitingTimeMessage") + ' ' + '<span id="component_streamcomponent_waitingtimes_seconds">' + formattedWaitingTime + '</span></div>'
 
             document.getElementById('component_streamcomponent_waitingtimes').innerHTML = html
 
@@ -337,15 +339,15 @@ function StreamComponent({
         const seconds = (rawSeconds % 3600) % 60
 
         if (hours > 0) {
-            formattedText += hours + ' hour(s), '
+            formattedText += hours + ' ' + t("streamWindow.timeHours") + ', '
         }
 
         if (minutes > 0) {
-            formattedText += minutes + ' minute(s), '
+            formattedText += minutes + ' ' + t("streamWindow.timeMinutes") + ', '
         }
 
         if (seconds > 0) {
-            formattedText += seconds + ' second(s).'
+            formattedText += seconds + ' ' + t("streamWindow.timeSeconds") + '.'
         }
 
         return formattedText
@@ -359,11 +361,11 @@ function StreamComponent({
 
                 <div id="component_streamcomponent_loader">
                     <Card className='padbottom'>
-                        <h1>Loading...</h1>
+                        <h1>{t("streamWindow.loadingStreamTitle")}</h1>
 
                         <Loader></Loader>
 
-                        <p>We are getting your stream ready...</p>
+                        <p>{t("streamWindow.gettingStreamReadyMessage")}</p>
                         <p id="component_streamcomponent_connectionstatus"></p>
 
                         <p id="component_streamcomponent_waitingtimes"></p>
@@ -375,10 +377,10 @@ function StreamComponent({
                         <div style={{
                             width: '25%',
                         }}>
-                            <Button label={<span><i className="fa-solid fa-xmark"></i> End Stream</span>} title="End Stream" className='btn-cancel' onClick={() => {
+                            <Button label={<span><i className="fa-solid fa-xmark"></i> {t("streamWindow.endStreamBtn")}</span>} title={t("streamWindow.endStreamBtn")} className='btn-cancel' onClick={() => {
                                 endStream()
                             }}></Button> &nbsp;
-                            <Button label={<span><i className="fa-solid fa-xmark"></i></span>} title="Disconnect" className='btn' onClick={() => {
+                            <Button label={<span><i className="fa-solid fa-xmark"></i></span>} title={t("streamWindow.disconnectBtn")} className='btn' onClick={() => {
                                 streamDisconnect()
                             }}></Button>
                         </div>
@@ -387,10 +389,10 @@ function StreamComponent({
                             marginLeft: 'auto',
                             marginRight: 'auto',
                         }}>
-                            <Button label={<span><i className="fa-brands fa-xbox"></i> Menu</span>} title="Open Xbox menu" onClick={(e) => {
+                            <Button label={<span><i className="fa-brands fa-xbox"></i> {t("streamWindow.menuBtn")}</span>} title={t("streamWindow.menuTitle")} onClick={(e) => {
                                 e.target.blur(); onMenu()
                             }}></Button> &nbsp;
-                            <Button label={(micStatus === false) ? <span><i className="fa-solid fa-microphone-slash"></i> Muted</span> : <span><i className="fa-solid fa-microphone"></i> Active</span>} title={(micStatus === false) ? 'Enable mic' : 'Disable mic'} className={(micStatus === false) ? 'btn-cancel' : 'btn-primary'} onClick={(e) => {
+                            <Button label={(micStatus === false) ? <span><i className="fa-solid fa-microphone-slash"></i> {t("streamWindow.micMuted")}</span> : <span><i className="fa-solid fa-microphone"></i> {t("streamWindow.micActive")}</span>} title={(micStatus === false) ? t("streamWindow.enableMic") : t("streamWindow.disableMic")} className={(micStatus === false) ? 'btn-cancel' : 'btn-primary'} onClick={(e) => {
                                 e.target.blur(); toggleMic()
                             }}></Button>
                         </div>
@@ -411,7 +413,7 @@ function StreamComponent({
                             width: '25%',
                             textAlign: 'right',
                         }}>
-                            <Button label={<i className="fa-solid fa-bug"></i>} title="Debug" onClick={(e) => {
+                            <Button label={<i className="fa-solid fa-bug"></i>} title={t("streamWindow.debugTitle")} onClick={(e) => {
                                 e.target.blur(); toggleDebug()
                             }}></Button>
                         </div>
@@ -419,7 +421,7 @@ function StreamComponent({
                 </div>
 
                 <div id="component_streamcomponent_debug" className='hidden'>
-                    <p>Debug:</p>
+                    <p>{t("streamWindow.debugTitle")}:</p>
 
                     <div id="component_streamcomponent_debug_webrtc_jitter"></div>
                     <div id="component_streamcomponent_debug_webrtc_dropped"></div>

--- a/packages/desktop/renderer/components/ui/streampreload.tsx
+++ b/packages/desktop/renderer/components/ui/streampreload.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import Loader from './loader'
 import Card from './card'
 import Button from './button'
+import { useTranslation } from 'react-i18next'
 
 interface StreamPreloadProps {
   onDisconnect?: () => void;
@@ -12,13 +13,14 @@ function StreamPreload({
     onDisconnect,
     waitingTime = 0,
 }: StreamPreloadProps) {
-    const [waitingSeconds, setWaitingSeconds] = React.useState(-1)  
+    const { t } = useTranslation()
+    const [waitingSeconds, setWaitingSeconds] = React.useState(-1)
     // console.log('outeffect', waitingTime, waitingSeconds)
 
     if(waitingSeconds < 0 && waitingTime > 0){
         // console.log('setWaitingSeconds', waitingTime)
         setWaitingSeconds(waitingTime)
-        
+
     } else if(waitingSeconds > 0){
         // console.log('drawWaitingTimes', waitingSeconds)
         drawWaitingTimes(waitingSeconds)
@@ -27,13 +29,13 @@ function StreamPreload({
     React.useEffect(() => {
 
         return () => {
-            
+
         }
     }, [])
 
     function drawWaitingTimes(seconds){
         const formattedWaitingTime = formatWaitingTime(seconds)
-        const html = '<div>Estimated waiting time in queue: <span id="component_streamcomponent_waitingtimes_seconds">'+formattedWaitingTime+'</span></div>'
+        const html = '<div>' + t("streamWindow.estimatedWaitingTimeMessage") + ' ' + '<span id="component_streamcomponent_waitingtimes_seconds">'+formattedWaitingTime+'</span></div>'
 
         document.getElementById('component_streamcomponent_waitingtimes').innerHTML = html
 
@@ -58,7 +60,7 @@ function StreamPreload({
     }
 
     function endStream(){
-        if(confirm('Are you sure you want to end your stream?')){
+        if(confirm(t('streamWindow.endStreamConfirmation'))){
             onDisconnect()
             window.history.back()
         }
@@ -72,19 +74,19 @@ function StreamPreload({
         const seconds = (rawSeconds % 3600) % 60
 
         if (hours > 0) {
-            formattedText += hours + ' hour(s), '
+            formattedText += hours + ' ' + t("streamWindow.timeHours") + ', '
         }
 
         if (minutes > 0) {
-            formattedText += minutes + ' minute(s), '
+            formattedText += minutes + ' ' + t("streamWindow.timeMinutes") + ', '
         }
 
         if (seconds >= 0) {
-            formattedText += seconds + ' second(s).'
+            formattedText += seconds + ' ' + t("streamWindow.timeSeconds") + '.'
         }
 
         if(seconds === 0){
-            formattedText += '\nIt\'s taking a little longer.. Your stream may start soon.'
+            formattedText += t('streamWindow.itsTakingALittleLonger')
         }
 
         return formattedText
@@ -98,11 +100,11 @@ function StreamPreload({
 
                 <div id="component_streamcomponent_loader">
                     <Card className='padbottom'>
-                        <h1>Loading...</h1>
+                        <h1>{t("streamWindow.loadingStreamTitle")}</h1>
 
                         <Loader></Loader>
 
-                        <p>We are getting your stream ready...</p>
+                        <p>{t("streamWindow.gettingStreamReadyMessage")}</p>
                         <p id="component_streamcomponent_connectionstatus"></p>
 
                         <p id="component_streamcomponent_waitingtimes"></p>
@@ -114,11 +116,11 @@ function StreamPreload({
                         <div style={{
                             width: '25%',
                         }}>
-                            <Button label={<span><i className="fa-solid fa-xmark"></i> End Stream</span>} title="End Stream" className='btn-cancel' onClick={ () => {
-                                endStream() 
+                            <Button label={<span><i className="fa-solid fa-xmark"></i> {t("streamWindow.endStreamBtn")}</span>} title={t("streamWindow.endStreamBtn")} className='btn-cancel' onClick={ () => {
+                                endStream()
                             } }></Button> &nbsp;
-                            <Button label={<span><i className="fa-solid fa-xmark"></i></span>} title="Disconnect" className='btn' onClick={ () => {
-                                streamDisconnect() 
+                            <Button label={<span><i className="fa-solid fa-xmark"></i></span>} title={t("streamWindow.disconnectBtn")} className='btn' onClick={ () => {
+                                streamDisconnect()
                             } }></Button>
                         </div>
                     </div>

--- a/packages/desktop/renderer/components/ui/viewportgrid.tsx
+++ b/packages/desktop/renderer/components/ui/viewportgrid.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Button from './button'
+import { useTranslation } from 'react-i18next'
 
 interface ViewportGridProps {
     drawPagination?:boolean;
@@ -15,6 +16,7 @@ function ViewportGrid({
     const randomId = Math.floor(Math.random()*1000)
     const [showItems, setShowItems] = React.useState(9999)
     const [page, setPage] = React.useState(0)
+    const { t } = useTranslation()
 
     React.useEffect(() => {
         // Mount
@@ -85,12 +87,12 @@ function ViewportGrid({
     function drawPageButtons(){
         const buttons = []
         const totalPages = Math.ceil(Object.keys(children).length/showItems)
-      
-        buttons.push((<Button key="page_prev" onClick={ prevPage } disabled={page <= 0} className='btn-small' label="Previous page"></Button>))
+
+        buttons.push((<Button key="page_prev" onClick={ prevPage } disabled={page <= 0} className='btn-small' label={t('page.xCloudLibrary.previousPageBtn')}></Button>))
         for(let i=1; i <= totalPages; i++){
             if(i === 1 || (i > (page-4) && i <= (page+5)) || i === totalPages){
                 buttons.push((<Button key={i} label={i.toString()} className={ page === (i-1) ? 'btn-small btn-primary': 'btn-small' } onClick={ () => {
-                    gotoPage(i) 
+                    gotoPage(i)
                 }}></Button>))
             } else {
                 if(i === (page-4) || i === (page+6)){
@@ -98,8 +100,8 @@ function ViewportGrid({
                 }
             }
         }
-        buttons.push((<Button key="page_next" onClick={ nextPage } disabled={page >= totalPages-1} className='btn-small' label="Next page"></Button>))
-    
+        buttons.push((<Button key="page_next" onClick={ nextPage } disabled={page >= totalPages-1} className='btn-small' label={t('page.xCloudLibrary.nextPageBtn')}></Button>))
+
         return buttons
     }
 
@@ -107,12 +109,12 @@ function ViewportGrid({
         setPage(page+1)
         window.scrollTo({ top: 0 })
     }
-    
+
     function prevPage(){
         setPage(page-1)
         window.scrollTo({ top: 0 })
     }
-    
+
     function gotoPage(page){
         setPage(parseInt(page)-1)
         window.scrollTo({ top: 0 })
@@ -136,7 +138,7 @@ function ViewportGrid({
                     const limit = (page*showItems)+showItems
 
                     if(index < offset || index >= limit){
-                        return 
+                        return
                     }
 
                     return ( <div id={ 'title_'+index } style={{

--- a/packages/desktop/renderer/context/languageContext.tsx
+++ b/packages/desktop/renderer/context/languageContext.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { useSettings } from './userContext';
+import { initI18nWithLanguage } from '../lib/i18n';
+
+// Language context for instant switching
+export const LanguageContext = createContext({
+  language: 'en-US',
+  setLanguage: (lang: string) => {},
+});
+
+export const LanguageProvider = ({ children }) => {
+  const { settings, setSettings } = useSettings();
+  const [language, setLanguageState] = useState<string | undefined>();
+
+  // Update language in settings and state
+  const setLanguage = (lang: string) => {
+    setLanguageState(lang);
+    setSettings({ ...settings, language: lang }); // Save to global settings
+  };
+
+  // Sync language from settings on mount/settings change
+  useEffect(() => {
+    if (settings.language && settings.language !== language) {
+      setLanguageState(settings.language);
+    }
+    // Always re-init i18n when settings.language changes
+    initI18nWithLanguage(settings);
+  }, [settings.language]);
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => useContext(LanguageContext);

--- a/packages/desktop/renderer/context/userContext.defaults.ts
+++ b/packages/desktop/renderer/context/userContext.defaults.ts
@@ -42,4 +42,7 @@ export const defaultSettings = {
     // WebUI
     webui_autostart: false,
     webui_port: 9003,
+
+    // Selected language for i18n
+    language: 'en-US',
 }

--- a/packages/desktop/renderer/languages/en-US.json
+++ b/packages/desktop/renderer/languages/en-US.json
@@ -1,0 +1,286 @@
+{
+  "translation": {
+    "languageName": "English",
+    "authorOfLocalization": "English Localization by unknownskl",
+
+    "header": {
+      "myConsoles": "My Consoles",
+      "viewConsoles": "View consoles",
+      "xCloudLibrary": "xCloud Library",
+      "browseXCloudLibrary": "Browse xCloud library",
+      "settings": "Settings",
+      "changeSettings": "Change application settings",
+      "viewProfile": "View profile",
+      "quitQuestion": "Are you sure you want to quit?",
+      "home": "Home"
+    },
+
+    "auth": {
+      "logoutQuestion": "Are you sure you want to logout?",
+      "clearDataBtn": "Clear Data",
+      "clearDataQuestion": "This will remove all application data, which is sometimes helpful when you are stuck in a login loop. Do you want to continue?",
+      "gamerscore": "Gamerscore",
+      "loggingIn": "Logging in...",
+      "loginBtn": "Login",
+      "logoutBtn": "Logout",
+      "loginWithXbox": "Login with Xbox",
+      "pleaseAuthenticate": "Please authenticate below to access xCloud and xHome Streaming",
+      "windowTitle": "Authentication"
+    },
+
+    "settings": {
+      "sidebar": {
+        "about": "About",
+        "streaming": "Streaming",
+        "input": "Input",
+        "videoAudio": "Video & Audio",
+        "webUI": "Web UI",
+        "debug": "Debug"
+      },
+
+      "about": {
+        "logoutQuestion": "Are you sure you want to logout?",
+        "title": "Settings",
+        "gamerscore": "Gamerscore",
+        "selectorSelectLanguage": "Select language",
+        "logout": "Logout",
+        "version": "Version",
+        "website": "Website",
+        "websiteLinkTitle": "Open link in external browser"
+      },
+
+      "input": {
+        "settingsInputPageTitle": "Settings: Input",
+        "dPadUp": "DPad Up",
+        "dPadDown": "DPad Down",
+        "dPadLeft": "DPad Left",
+        "dPadRight": "DPad Right",
+        "leftShoulder": "Left Shoulder",
+        "rightShoulder": "Right Shoulder",
+        "leftTrigger": "Left Trigger",
+        "rightTrigger": "Right Trigger",
+        "leftThumb": "Left Thumbstick",
+        "rightThumb": "Right Thumbstick",
+        "view": "View",
+        "menu": "Menu",
+        "nexus": "Nexus",
+        "none": "None",
+        "enabledLabel": "Enabled",
+        "disabledLabel": "Disabled",
+        "axesLabel": "axes",
+        "buttonsLabel": "buttons",
+        "rumbleLabel": "rumble",
+        "notSupportedLabel": "Not supported",
+        "title": "Input",
+        "enableVibration": "Enable vibration",
+        "enableTouch": "Enable Touch input",
+        "enableMouseKeyboard": "Enable Mouse & Keyboard",
+        "legacyWarning": "Using the Mouse & Keyboard driver together with the Gamepad keyboard mappings will cause conflicts",
+        "enableLegacy": "Enable Keyboard to Gamepad",
+        "enableLegacyDescription": "(Disabling this feature will disable the keyboard to gamepad mapping and only allows controls from the gamepad.)",
+        "controllerDetectedTitle": "Controllers detected",
+        "controllerDetectedDescription": "If you have a controller connected but it is not showing up, try to press a button on the controller to detect it.",
+        "noControllerDetected": "No controller detected",
+        "keyboardMappingsTitle": "Keyboard mappings"
+      },
+
+      "streaming": {
+        "pageTitle": "Settings: Streaming",
+        "title": "Streaming Settings",
+        "description": "xHome and xCloud do not support more than 20mbps by default. This setting does not override this limit.",
+        "xCloudStreamingBitrateLabel": "xCloud Streaming Bitrate",
+        "xHomeStreamingBitrateLabel": "xHome Streaming Bitrate",
+        "unlimitedLabel": "Unlimited / Off",
+        "mbpsLabel": "mbps",
+        "setH264ProfileLabel": "Set H.264 Profile",
+        "setH264ProfileValueAuto": "Auto-Negotiate",
+        "setH264ProfileValueHigh": "High",
+        "setH264ProfileValueMedium": "Medium",
+        "setH264ProfileValueLow": "Low",
+        "forceRegionTitle": "Force region",
+        "setRegionLabel": "Set region:",
+        "setRegionValueDisabled": "Disabled",
+        "setRegionValueAustralia": "Australia",
+        "setRegionValueBrazil": "Brazil",
+        "setRegionValueEurope": "Europe",
+        "setRegionValueJapan": "Japan",
+        "setRegionValueKorea": "Korea",
+        "setRegionValueUS": "United States",
+        "preferredGameLanguageLabel": "Preferred game language:",
+        "preferredGameLanguageValueArabic": "Arabic (Saudi Arabia)",
+        "preferredGameLanguageValueCzech": "Czech",
+        "preferredGameLanguageValueDanish": "Danish",
+        "preferredGameLanguageValueGerman": "German",
+        "preferredGameLanguageValueGreek": "Greek",
+        "preferredGameLanguageValueEnglishUK": "English (United Kingdom)",
+        "preferredGameLanguageValueEnglishUS": "English (United States)",
+        "preferredGameLanguageValueSpanish": "Spanish (Spain)",
+        "preferredGameLanguageValueSpanishMX": "Spanish (Mexico)",
+        "preferredGameLanguageValueFinnish": "Finnish",
+        "preferredGameLanguageValueFrench": "French",
+        "preferredGameLanguageValueHebrew": "Hebrew",
+        "preferredGameLanguageValueHungarian": "Hungarian",
+        "preferredGameLanguageValueItalian": "Italian",
+        "preferredGameLanguageValueJapanese": "Japanese",
+        "preferredGameLanguageValueKorean": "Korean",
+        "preferredGameLanguageValueNorwegian": "Norwegian",
+        "preferredGameLanguageValueDutch": "Dutch",
+        "preferredGameLanguageValuePolish": "Polish",
+        "preferredGameLanguageValuePortugueseBR": "Portuguese (Brazil)",
+        "preferredGameLanguageValuePortuguese": "Portuguese (Portugal)",
+        "preferredGameLanguageValueRussian": "Russian",
+        "preferredGameLanguageValueSlovak": "Slovak",
+        "preferredGameLanguageValueSwedish": "Swedish",
+        "preferredGameLanguageValueTurkish": "Turkish",
+        "preferredGameLanguageValueChineseCN": "Chinese (Simplified)",
+        "preferredGameLanguageValueChineseTW": "Chinese (Traditional)"
+      },
+
+      "videoAudio": {
+        "pageTitle": "Settings: Video & Audio",
+        "title": "Video",
+        "disableVideoLabel": "Disable video",
+        "disabledLabel": "Disabled",
+        "enabledLabel": "Enabled",
+        "aspectSizeLabel": "Video aspect size",
+        "aspectSizeValueDefault": "Default",
+        "aspectSizeValueStretch": "Stretch",
+        "aspectSizeValueZoom": "Zoom",
+        "forceLowResLabel": "Force low resolution video",
+        "forceLowResDescription": "(This option is useful on the Steam Deck and enables the application to render in a low resolution so FSR can be enabled.)",
+        "audioTitle": "Audio",
+        "disableAudioLabel": "Disable audio"
+      },
+
+      "webUI": {
+        "pageTitle": "Settings: Web UI",
+        "title": "WebUI",
+        "enableWebUILabel": "Enable WebUI",
+        "stopWebUIBtn": "Stop Web UI",
+        "startWebUIBtn": "Start Web UI",
+        "openWebUIBtn": "Open Web UI",
+        "autostartLabel": "Start WebUI on application start",
+        "autostartEnabled": "Enabled",
+        "autostartDisabled": "Disabled",
+        "portLabel": "Port",
+        "portPlaceholder": "example: 9003"
+      },
+
+      "debug": {
+        "pageTitle": "Settings: Debug"
+      }
+    },
+
+    "page": {
+      "xCloud": {
+        "pageTitle": "xCloud Library",
+        "breadcrumb": "xCloud",
+        "recentGames": "Recent Games",
+        "recentlyAdded": "Recently added",
+        "viewLibraryBtn": "View Library"
+      },
+
+      "xCloudLibrary": {
+        "pageTitle": "xCloud Library",
+        "breadcrumb1": "xCloud",
+        "breadcrumb2": "Library",
+        "title": "Library",
+        "searchPlaceholder": "Search",
+        "previousPageBtn": "Previous Page",
+        "nextPageBtn": "Next Page",
+        "viewGamePageIcon": "View game page"
+      },
+
+      "myConsoles": {
+        "pageTitle": "My Consoles",
+        "poweredOn": "Powered on",
+        "standby": "Standby",
+        "warningLabel": "Warning",
+        "managementWarning": "Remote management not enabled",
+        "streamingWarning": "Console streaming not enabled",
+        "startStreamBtn": "Start Stream",
+        "noConsoles": "No consoles found on your account. If you do have an Xbox console then make sure that remote playing is enabled and that the console is visible in the official Xbox App."
+      },
+
+      "titleInfo": {
+        "pageTitle": "Viewing title information:",
+        "breadcrumb1": "xCloud",
+        "breadcrumb2": "Library",
+        "by": "by",
+        "descriptionTitle": "Description",
+        "capabilitiesTitle": "Capabilities",
+        "startStreamBtn": "Start Stream"
+      },
+
+      "page404": {
+        "pageTitle": "Error",
+        "message": "Oopsie 404.. Action not found"
+      },
+
+      "page500": {
+        "pageTitle": "Error",
+        "message": "Oopsie 500.. Application has an error"
+      }
+    },
+
+    "friends": {
+      "allFriendsOffline": "All your friends are offline"
+    },
+
+    "streamWindow": {
+      "pageTitle": "Streaming",
+      "endStreamConfirmMessage": "Are you sure you want to end your stream?",
+      "estimatedWaitingTimeMessage": "Estimated waiting time in queue:",
+      "timeHours": "hour(s)",
+      "timeMinutes": "minute(s)",
+      "timeSeconds": "second(s)",
+      "loadingStreamTitle": "Loading...",
+      "gettingStreamReadyMessage": "We are getting your stream ready...",
+      "endStreamBtn": "End Stream",
+      "disconnectBtn": "Disconnect",
+      "menuBtn": "Menu",
+      "menuTitle": "Open Xbox menu",
+      "micMuted": "Muted",
+      "micActive": "Active",
+      "enableMic": "Enable mic",
+      "disableMic": "Disable mic",
+      "debugTitle": "Debug",
+      "itsTakingALittleLonger": "It's taking a little longer.. Your stream may start soon.",
+      "startingConnection": "Starting connection...",
+      "connectingToConsole": "Connecting to console...",
+      "clientHasBeenDisconnected": "The client has been disconnected."
+    },
+
+    "updater": {
+      "unableToCheckForUpdates": "Unable to check for updates at this moment. Try again.",
+      "alreadyOnLatestVersion": "You are already running the latest version. Current version:",
+      "newestVersion": "Newest version:",
+      "newReleaseAvailable": "New release available",
+      "installedVersion": "Installed version:",
+      "latestVersion": "Latest version:",
+      "downloadBtn": "Download",
+      "laterBtn": "Later",
+      "updateChecker": "Update Checker",
+      "closeBtn": "Close"
+    },
+
+    "errors": {
+      "failedToRetrieveUserProfile": "Error: Failed to retrieve user profile:",
+      "repositoryNotFound": "Repository URL not found in package.json file.",
+      "failedToRetrieveStreamingTokens": "Error: Failed to retrieve streaming tokens:",
+      "errorAuthentificationUser": "Error authenticating user. Error details:",
+      "errorGettingRedirectURI": "Error getting redirect URI. Error details:",
+      "authentificationCallbackIsNotDefined": "Authentication Callback is not defined. Error details:",
+      "sisuTokenIsMissing": "Sisu token is missing. Please authenticate first",
+      "failedToRetrieveWebTokens": "Error: Failed to retrieve web tokens:",
+      "chatSDPExchangeError": "ChatSDP Exchange error:",
+      "ICEExchangeError": "ICE Exchange error:",
+      "SDPExchangeError": "SDP Exchange error:",
+      "failedToStartStream": "Failed to start new stream. Error details:",
+      "unableToStartStreamSession": "Unable to start stream session on console. The console is not connected to the Xbox servers. This occasionally happens when there is an update or when the user is not signed in to the console. Please hard reboot your console and try again.",
+      "streamErrorResult": "Stream error result:",
+      "details": "Details:",
+      "failedToGetPlayerState": "Failed to get player state. Error details:"
+    }
+  }
+}

--- a/packages/desktop/renderer/languages/ru-RU.json
+++ b/packages/desktop/renderer/languages/ru-RU.json
@@ -1,0 +1,286 @@
+{
+  "translation": {
+    "languageName": "Русский",
+    "authorOfLocalization": "Русская локализация: Евгений Чефранов",
+
+    "header": {
+      "myConsoles": "Мои консоли",
+      "viewConsoles": "Просмотр консолей",
+      "xCloudLibrary": "Библиотека xCloud",
+      "browseXCloudLibrary": "Просмотреть библиотеку xCloud",
+      "settings": "Настройки",
+      "changeSettings": "Изменить настройки приложения",
+      "viewProfile": "Просмотреть профиль",
+      "quitQuestion": "Вы уверены, что хотите выйти?",
+      "home": "Главная"
+    },
+
+    "auth": {
+      "logoutQuestion": "Вы уверены, что хотите выйти из аккаунта?",
+      "clearDataBtn": "Очистить данные",
+      "clearDataQuestion": "Это удалит все данные приложения, что иногда помогает, если вы застряли в цикле входа. Продолжить?",
+      "gamerscore": "Игровой счет",
+      "loggingIn": "Вход...",
+      "loginBtn": "Войти",
+      "logoutBtn": "Выйти",
+      "loginWithXbox": "Войти через Xbox",
+      "pleaseAuthenticate": "Пожалуйста, авторизуйтесь ниже для доступа к xCloud и xHome Streaming",
+      "windowTitle": "Авторизация"
+    },
+
+    "settings": {
+      "sidebar": {
+        "about": "О программе",
+        "streaming": "Трансляция",
+        "input": "Ввод",
+        "videoAudio": "Видео и аудио",
+        "webUI": "Web UI",
+        "debug": "Отладка"
+      },
+
+      "about": {
+        "logoutQuestion": "Вы уверены, что хотите выйти из аккаунта?",
+        "title": "Настройки",
+        "gamerscore": "Игровой счет",
+        "selectorSelectLanguage": "Выберите язык",
+        "logout": "Выйти",
+        "version": "Версия",
+        "website": "Веб-сайт",
+        "websiteLinkTitle": "Открыть ссылку во внешнем браузере"
+      },
+
+      "input": {
+        "pageTitle": "Настройки: Ввод",
+        "dPadUp": "Крестовина вверх",
+        "dPadDown": "Крестовина вниз",
+        "dPadLeft": "Крестовина влево",
+        "dPadRight": "Крестовина вправо",
+        "leftShoulder": "Левый бампер",
+        "rightShoulder": "Правый бампер",
+        "leftTrigger": "Левый триггер",
+        "rightTrigger": "Правый триггер",
+        "leftThumb": "Левый стик",
+        "rightThumb": "Правый стик",
+        "view": "Просмотр",
+        "menu": "Меню",
+        "nexus": "Nexus",
+        "none": "Нет",
+        "enabledLabel": "Включено",
+        "disabledLabel": "Отключено",
+        "axesLabel": "оси",
+        "buttonsLabel": "кнопок",
+        "rumbleLabel": "вибрация",
+        "notSupportedLabel": "Не поддерживается",
+        "title": "Ввод",
+        "enableVibration": "Включить вибрацию",
+        "enableTouch": "Включить сенсорный ввод",
+        "enableMouseKeyboard": "Включить мышь и клавиатуру",
+        "legacyWarning": "Использование драйвера мыши и клавиатуры вместе с назначениями клавиш геймпада вызовет конфликты",
+        "enableLegacy": "Включить клавиатуру как геймпад",
+        "enableLegacyDescription": "(Отключение этой функции отключит сопоставление клавиатуры с геймпадом и позволит управлять только с геймпада.)",
+        "controllerDetectedTitle": "Обнаружены контроллеры",
+        "controllerDetectedDescription": "Если у вас подключен контроллер, но он не отображается, попробуйте нажать кнопку на контроллере для обнаружения.",
+        "noControllerDetected": "Контроллер не обнаружен",
+        "keyboardMappingsTitle": "Назначения клавиш"
+      },
+
+      "streaming": {
+        "pageTitle": "Настройки: Трансляция",
+        "title": "Настройки трансляции",
+        "description": "xHome и xCloud по умолчанию не поддерживают более 20 Мбит/с. Эта настройка не отменяет это ограничение.",
+        "xCloudStreamingBitrateLabel": "Битрейт трансляции xCloud",
+        "xHomeStreamingBitrateLabel": "Битрейт трансляции xHome",
+        "unlimitedLabel": "Без ограничений / Выкл.",
+        "mbpsLabel": "Мбит/с",
+        "setH264ProfileLabel": "Установить профиль H.264",
+        "setH264ProfileValueAuto": "Авто-выбор",
+        "setH264ProfileValueHigh": "Высокий",
+        "setH264ProfileValueMedium": "Средний",
+        "setH264ProfileValueLow": "Низкий",
+        "forceRegionTitle": "Принудительный регион",
+        "setRegionLabel": "Установить регион:",
+        "setRegionValueDisabled": "Отключено",
+        "setRegionValueAustralia": "Австралия",
+        "setRegionValueBrazil": "Бразилия",
+        "setRegionValueEurope": "Европа",
+        "setRegionValueJapan": "Япония",
+        "setRegionValueKorea": "Корея",
+        "setRegionValueUS": "США",
+        "preferredGameLanguageLabel": "Предпочтительный язык игры:",
+        "preferredGameLanguageValueArabic": "Арабский (Саудовская Аравия)",
+        "preferredGameLanguageValueCzech": "Чешский",
+        "preferredGameLanguageValueDanish": "Датский",
+        "preferredGameLanguageValueGerman": "Немецкий",
+        "preferredGameLanguageValueGreek": "Греческий",
+        "preferredGameLanguageValueEnglishUK": "Английский (Великобритания)",
+        "preferredGameLanguageValueEnglishUS": "Английский (США)",
+        "preferredGameLanguageValueSpanish": "Испанский (Испания)",
+        "preferredGameLanguageValueSpanishMX": "Испанский (Мексика)",
+        "preferredGameLanguageValueFinnish": "Финский",
+        "preferredGameLanguageValueFrench": "Французский",
+        "preferredGameLanguageValueHebrew": "Иврит",
+        "preferredGameLanguageValueHungarian": "Венгерский",
+        "preferredGameLanguageValueItalian": "Итальянский",
+        "preferredGameLanguageValueJapanese": "Японский",
+        "preferredGameLanguageValueKorean": "Корейский",
+        "preferredGameLanguageValueNorwegian": "Норвежский",
+        "preferredGameLanguageValueDutch": "Голландский",
+        "preferredGameLanguageValuePolish": "Польский",
+        "preferredGameLanguageValuePortugueseBR": "Португальский (Бразилия)",
+        "preferredGameLanguageValuePortuguese": "Португальский (Португалия)",
+        "preferredGameLanguageValueRussian": "Русский",
+        "preferredGameLanguageValueSlovak": "Словацкий",
+        "preferredGameLanguageValueSwedish": "Шведский",
+        "preferredGameLanguageValueTurkish": "Турецкий",
+        "preferredGameLanguageValueChineseCN": "Китайский (упрощенный)",
+        "preferredGameLanguageValueChineseTW": "Китайский (традиционный)"
+      },
+
+      "videoAudio": {
+        "pageTitle": "Настройки: Видео и Аудио",
+        "videoTitle": "Видео",
+        "disableVideoLabel": "Отключить видео",
+        "disabledLabel": "Отключено",
+        "enabledLabel": "Включено",
+        "aspectSizeLabel": "Размер видео",
+        "aspectSizeValueDefault": "По умолчанию",
+        "aspectSizeValueStretch": "Растянуть",
+        "aspectSizeValueZoom": "Зум",
+        "forceLowResLabel": "Принудительно низкое разрешение видео",
+        "forceLowResDescription": "(Эта опция полезна на Steam Deck и позволяет приложению работать в низком разрешении, чтобы можно было включить FSR.)",
+        "audioTitle": "Аудио",
+        "disableAudioLabel": "Отключить аудио"
+      },
+
+      "webUI": {
+        "pageTitle": "Настройки: Web UI",
+        "title": "WebUI",
+        "enableWebUILabel": "Включить WebUI",
+        "stopWebUIBtn": "Остановить Web UI",
+        "startWebUIBtn": "Запустить Web UI",
+        "openWebUIBtn": "Открыть Web UI",
+        "autostartLabel": "Запускать WebUI при старте приложения",
+        "autostartEnabled": "Включено",
+        "autostartDisabled": "Отключено",
+        "portLabel": "Порт",
+        "portPlaceholder": "например: 9003"
+      },
+
+      "debug": {
+        "pageTitle": "Настройки: Отладка"
+      }
+    },
+
+    "page": {
+      "xCloud": {
+        "pageTitle": "Библиотека xCloud",
+        "breadcrumb": "xCloud",
+        "recentGames": "Недавние игры",
+        "recentlyAdded": "Недавно добавленные",
+        "viewLibraryBtn": "Просмотреть библиотеку"
+      },
+
+      "xCloudLibrary": {
+        "pageTitle": "Библиотека xCloud",
+        "breadcrumb1": "xCloud",
+        "breadcrumb2": "Библиотека",
+        "title": "Библиотека",
+        "searchPlaceholder": "Поиск",
+        "previousPageBtn": "Предыдущая страница",
+        "nextPageBtn": "Следующая страница",
+        "viewGamePageIcon": "Просмотреть страницу игры"
+      },
+
+      "myConsoles": {
+        "pageTitle": "Мои консоли",
+        "poweredOn": "Включена",
+        "standby": "Режим ожидания",
+        "warningLabel": "Внимание",
+        "managementWarning": "Удалённое управление не включено",
+        "streamingWarning": "Потоковая передача с консоли не включена",
+        "startStreamBtn": "Начать трансляцию",
+        "noConsoles": "Консоли не найдены в вашем аккаунте. Если у вас есть консоль Xbox, убедитесь, что удалённая игра включена и консоль отображается в официальном приложении Xbox."
+      },
+
+      "titleInfo": {
+        "pageTitle": "Просмотр информации о тайтле:",
+        "breadcrumb1": "xCloud",
+        "breadcrumb2": "Библиотека",
+        "by": "От",
+        "descriptionTitle": "Описание",
+        "capabilitiesTitle": "Возможности",
+        "startStreamBtn": "Начать трансляцию"
+      },
+
+      "page404": {
+        "pageTitle": "Ошибка",
+        "message": "Упс.. 404.. Действие не найдено"
+      },
+
+      "page500": {
+        "pageTitle": "Ошибка",
+        "message": "Упс.. 500.. В приложении произошла ошибка"
+      }
+    },
+
+    "friends": {
+      "AllFriendsOffline": "Все ваши друзья оффлайн"
+    },
+
+    "streamWindow": {
+      "pageTitle": "Трансляция",
+      "endStreamConfirmMessage": "Вы уверены, что хотите завершить свою трансляцию?",
+      "estimatedWaitingTimeMessage": "Ожидаемое время ожидания в очереди:",
+      "timeHours": "час(ов)",
+      "timeMinutes": "минут(ы)",
+      "timeSeconds": "секунд(ы)",
+      "loadingStreamTitle": "Загрузка...",
+      "gettingStreamReadyMessage": "Мы подготавливаем вашу трансляцию...",
+      "endStreamBtn": "Завершить трансляцию",
+      "disconnectBtn": "Отключиться",
+      "menuBtn": "Меню",
+      "menuTitle": "Открыть меню Xbox",
+      "micMuted": "Выключен",
+      "micActive": "Включен",
+      "enableMic": "Включить микрофон",
+      "disableMic": "Выключить микрофон",
+      "debugTitle": "Отладка",
+      "itsTakingALittleLonger": "Это занимает немного больше времени.. Ваша трансляция может скоро начаться.",
+      "startingConnection": "Начало подключения...",
+      "connectingToConsole": "Подключение к консоли...",
+      "clientHasBeenDisconnected": "Клиент был отключен."
+    },
+
+    "updater": {
+      "unableToCheckForUpdates": "Не удалось проверить наличие обновлений в данный момент. Попробуйте еще раз.",
+      "alreadyOnLatestVersion": "Вы уже используете последнюю версию. Текущая версия:",
+      "newestVersion": "Последняя версия:",
+      "newReleaseAvailable": "Доступно новое обновление",
+      "installedVersion": "Установленная версия:",
+      "latestVersion": "Последняя версия:",
+      "downloadBtn": "Скачать",
+      "laterBtn": "Позже",
+      "updateChecker": "Проверка обновлений",
+      "closeBtn": "Закрыть"
+    },
+
+    "errors": {
+      "failedToRetrieveUserProfile": "Ошибка! Не удалось получить профиль пользователя:",
+      "repositoryNotFound": "Ошибка! URL репозитория не найден в файле package.json.",
+      "failedToRetrieveStreamingTokens": "Ошибка! Не удалось получить токены потоковой передачи:",
+      "errorAuthentificationUser": "Ошибка аутентификации пользователя. Подробности об ошибке:",
+      "errorGettingRedirectURI": "Ошибка получения URI перенаправления. Подробности об ошибке:",
+      "authentificationCallbackIsNotDefined": "Ошибка! Callback аутентификации не определён. Подробности об ошибке:",
+      "sisuTokenIsMissing": "Ошибка! Отсутствует токен Sisu. Пожалуйста, выполните аутентификацию сначала.",
+      "failedToRetrieveWebTokens": "Ошибка! Не удалось получить веб-токены:",
+      "chatSDPExchangeError": "Ошибка обмена ChatSDP:",
+      "ICEExchangeError": "Ошибка обмена ICE:",
+      "SDPExchangeError": "Ошибка обмена SDP:",
+      "failedToStartStream": "Не удалось запустить новую трансляцию. Подробности об ошибке:",
+      "unableToStartStreamSession": "Не удалось начать сессию трансляции на консоли. Консоль не подключена к серверам Xbox. Это иногда происходит, когда есть обновление или когда пользователь не вошел в систему на консоли. Пожалуйста, выполните жесткую перезагрузку консоли и попробуйте снова.",
+      "streamErrorResult": "Результат ошибки трансляции:",
+      "details": "Подробности:",
+      "failedToGetPlayerState": "Не удалось получить состояние игрока. Подробности об ошибке:"
+    }
+  }
+}

--- a/packages/desktop/renderer/languages/ru-RU.json
+++ b/packages/desktop/renderer/languages/ru-RU.json
@@ -224,7 +224,7 @@
     },
 
     "friends": {
-      "AllFriendsOffline": "Все ваши друзья оффлайн"
+      "allFriendsOffline": "Все ваши друзья оффлайн"
     },
 
     "streamWindow": {

--- a/packages/desktop/renderer/languages/uk-UA.json
+++ b/packages/desktop/renderer/languages/uk-UA.json
@@ -224,7 +224,7 @@
     },
 
     "friends": {
-      "AllFriendsOffline": "Всі ваші друзі офлайн"
+      "allFriendsOffline": "Всі ваші друзі офлайн"
     },
 
     "streamWindow": {

--- a/packages/desktop/renderer/languages/uk-UA.json
+++ b/packages/desktop/renderer/languages/uk-UA.json
@@ -1,0 +1,286 @@
+{
+  "translation": {
+    "languageName": "Українська",
+    "authorOfLocalization": "Українська локалізація: Євген Чефранов",
+
+    "header": {
+      "myConsoles": "Мої консолі",
+      "viewConsoles": "Перегляд консолей",
+      "xCloudLibrary": "Бібліотека xCloud",
+      "browseXCloudLibrary": "Переглянути бібліотеку xCloud",
+      "settings": "Налаштування",
+      "changeSettings": "Змінити налаштування додатку",
+      "viewProfile": "Переглянути профіль",
+      "quitQuestion": "Ви впевнені, що хочете вийти?",
+      "home": "Головна"
+    },
+
+    "auth": {
+      "logoutQuestion": "Ви впевнені, що хочете вийти з акаунту?",
+      "clearDataBtn": "Очистити дані",
+      "clearDataQuestion": "Це видалить всі дані додатку, що іноді допомагає, якщо ви застрягли у циклі входу. Продовжити?",
+      "gamerscore": "Ігровий рахунок",
+      "loggingIn": "Вхід...",
+      "loginBtn": "Увійти",
+      "logoutBtn": "Вийти",
+      "loginWithXbox": "Увійти через Xbox",
+      "pleaseAuthenticate": "Будь ласка, авторизуйтесь нижче для доступу до xCloud та xHome Streaming",
+      "windowTitle": "Авторизація"
+    },
+
+    "settings": {
+      "sidebar": {
+        "about": "Про програму",
+        "streaming": "Трансляція",
+        "input": "Ввід",
+        "videoAudio": "Відео та аудіо",
+        "webUI": "Web UI",
+        "debug": "Відлагодження"
+      },
+
+      "about": {
+        "logoutQuestion": "Ви впевнені, що хочете вийти з акаунту?",
+        "title": "Налаштування",
+        "gamerscore": "Ігровий рахунок",
+        "selectorSelectLanguage": "Оберіть мову",
+        "logout": "Вийти",
+        "version": "Версія",
+        "website": "Веб-сайт",
+        "websiteLinkTitle": "Відкрити посилання у зовнішньому браузері"
+      },
+
+      "input": {
+        "pageTitle": "Налаштування: Ввід",
+        "dPadUp": "Хрестовина вгору",
+        "dPadDown": "Хрестовина вниз",
+        "dPadLeft": "Хрестовина вліво",
+        "dPadRight": "Хрестовина вправо",
+        "leftShoulder": "Лівий бампер",
+        "rightShoulder": "Правий бампер",
+        "leftTrigger": "Лівий тригер",
+        "rightTrigger": "Правий тригер",
+        "leftThumb": "Лівий стик",
+        "rightThumb": "Правий стик",
+        "view": "Перегляд",
+        "menu": "Меню",
+        "nexus": "Nexus",
+        "none": "Немає",
+        "enabledLabel": "Увімкнено",
+        "disabledLabel": "Вимкнено",
+        "axesLabel": "осі",
+        "buttonsLabel": "кнопок",
+        "rumbleLabel": "вібрація",
+        "notSupportedLabel": "Не підтримується",
+        "title": "Ввід",
+        "enableVibration": "Увімкнути вібрацію",
+        "enableTouch": "Увімкнути сенсорний ввід",
+        "enableMouseKeyboard": "Увімкнути мишу та клавіатуру",
+        "legacyWarning": "Використання драйвера миші та клавіатури разом із призначеннями клавіш геймпада викличе конфлікти",
+        "enableLegacy": "Увімкнути клавіатуру як геймпад",
+        "enableLegacyDescription": "(Вимкнення цієї функції вимкне зіставлення клавіатури з геймпадом і дозволить керувати лише з геймпада.)",
+        "controllerDetectedTitle": "Виявлено контролери",
+        "controllerDetectedDescription": "Якщо у вас підключено контролер, але він не відображається, спробуйте натиснути кнопку на контролері для виявлення.",
+        "noControllerDetected": "Контролер не виявлено",
+        "keyboardMappingsTitle": "Призначення клавіш"
+      },
+
+      "streaming": {
+        "pageTitle": "Налаштування: Трансляція",
+        "title": "Налаштування трансляції",
+        "description": "xHome і xCloud за замовчуванням не підтримують більше 20 Мбіт/с. Ця настройка не скасовує це обмеження.",
+        "xCloudStreamingBitrateLabel": "Бітрейт трансляції xCloud",
+        "xHomeStreamingBitrateLabel": "Бітрейт трансляції xHome",
+        "unlimitedLabel": "Без обмежень / Викл.",
+        "mbpsLabel": "Мбіт/с",
+        "setH264ProfileLabel": "Встановити профіль H.264",
+        "setH264ProfileValueAuto": "Автовибір",
+        "setH264ProfileValueHigh": "Високий",
+        "setH264ProfileValueMedium": "Середній",
+        "setH264ProfileValueLow": "Низький",
+        "forceRegionTitle": "Примусовий регіон",
+        "setRegionLabel": "Встановити регіон:",
+        "setRegionValueDisabled": "Вимкнено",
+        "setRegionValueAustralia": "Австралія",
+        "setRegionValueBrazil": "Бразилія",
+        "setRegionValueEurope": "Європа",
+        "setRegionValueJapan": "Японія",
+        "setRegionValueKorea": "Корея",
+        "setRegionValueUS": "США",
+        "preferredGameLanguageLabel": "Бажана мова гри:",
+        "preferredGameLanguageValueArabic": "Арабська (Саудівська Аравія)",
+        "preferredGameLanguageValueCzech": "Чеська",
+        "preferredGameLanguageValueDanish": "Данська",
+        "preferredGameLanguageValueGerman": "Німецька",
+        "preferredGameLanguageValueGreek": "Грецька",
+        "preferredGameLanguageValueEnglishUK": "Англійська (Велика Британія)",
+        "preferredGameLanguageValueEnglishUS": "Англійська (США)",
+        "preferredGameLanguageValueSpanish": "Іспанська (Іспанія)",
+        "preferredGameLanguageValueSpanishMX": "Іспанська (Мексика)",
+        "preferredGameLanguageValueFinnish": "Фінська",
+        "preferredGameLanguageValueFrench": "Французька",
+        "preferredGameLanguageValueHebrew": "Іврит",
+        "preferredGameLanguageValueHungarian": "Угорська",
+        "preferredGameLanguageValueItalian": "Італійська",
+        "preferredGameLanguageValueJapanese": "Японська",
+        "preferredGameLanguageValueKorean": "Корейська",
+        "preferredGameLanguageValueNorwegian": "Норвезька",
+        "preferredGameLanguageValueDutch": "Голландська",
+        "preferredGameLanguageValuePolish": "Польська",
+        "preferredGameLanguageValuePortugueseBR": "Португальська (Бразилія)",
+        "preferredGameLanguageValuePortuguese": "Португальська (Португалія)",
+        "preferredGameLanguageValueRussian": "Російська",
+        "preferredGameLanguageValueSlovak": "Словацька",
+        "preferredGameLanguageValueSwedish": "Шведська",
+        "preferredGameLanguageValueTurkish": "Турецька",
+        "preferredGameLanguageValueChineseCN": "Китайська (спрощена)",
+        "preferredGameLanguageValueChineseTW": "Китайська (традиційна)"
+      },
+
+      "videoAudio": {
+        "pageTitle": "Налаштування: Відео та Аудіо",
+        "videoTitle": "Відео",
+        "disableVideoLabel": "Вимкнути відео",
+        "disabledLabel": "Вимкнено",
+        "enabledLabel": "Увімкнено",
+        "aspectSizeLabel": "Розмір відео",
+        "aspectSizeValueDefault": "За замовчуванням",
+        "aspectSizeValueStretch": "Розтягнути",
+        "aspectSizeValueZoom": "Зум",
+        "forceLowResLabel": "Примусово низька роздільна здатність відео",
+        "forceLowResDescription": "(Ця опція корисна на Steam Deck і дозволяє додатку працювати у низькій роздільній здатності, щоб можна було увімкнути FSR.)",
+        "audioTitle": "Аудіо",
+        "disableAudioLabel": "Вимкнути аудіо"
+      },
+
+      "webUI": {
+        "pageTitle": "Налаштування: Web UI",
+        "title": "WebUI",
+        "enableWebUILabel": "Увімкнути WebUI",
+        "stopWebUIBtn": "Зупинити Web UI",
+        "startWebUIBtn": "Запустити Web UI",
+        "openWebUIBtn": "Відкрити Web UI",
+        "autostartLabel": "Запускати WebUI при старті додатку",
+        "autostartEnabled": "Увімкнено",
+        "autostartDisabled": "Вимкнено",
+        "portLabel": "Порт",
+        "portPlaceholder": "наприклад: 9003"
+      },
+
+      "debug": {
+        "pageTitle": "Налаштування: Відлагодження"
+      }
+    },
+
+    "page": {
+      "xCloud": {
+        "pageTitle": "Бібліотека xCloud",
+        "breadcrumb": "xCloud",
+        "recentGames": "Недавні ігри",
+        "recentlyAdded": "Нещодавно додані",
+        "viewLibraryBtn": "Переглянути бібліотеку"
+      },
+
+      "xCloudLibrary": {
+        "pageTitle": "Бібліотека xCloud",
+        "breadcrumb1": "xCloud",
+        "breadcrumb2": "Бібліотека",
+        "title": "Бібліотека",
+        "searchPlaceholder": "Пошук",
+        "previousPageBtn": "Попередня сторінка",
+        "nextPageBtn": "Наступна сторінка",
+        "viewGamePageIcon": "Переглянути сторінку гри"
+      },
+
+      "myConsoles": {
+        "pageTitle": "Мої консолі",
+        "poweredOn": "Увімкнена",
+        "standby": "Режим очікування",
+        "warningLabel": "Увага",
+        "managementWarning": "Віддалене керування не увімкнено",
+        "streamingWarning": "Потокова передача з консолі не увімкнена",
+        "startStreamBtn": "Почати трансляцію",
+        "noConsoles": "Консолі не знайдено у вашому акаунті. Якщо у вас є консоль Xbox, переконайтеся, що віддалена гра увімкнена і консоль відображається в офіційному додатку Xbox."
+      },
+
+      "titleInfo": {
+        "pageTitle": "Перегляд інформації про тайтл:",
+        "breadcrumb1": "xCloud",
+        "breadcrumb2": "Бібліотека",
+        "by": "Від",
+        "descriptionTitle": "Опис",
+        "capabilitiesTitle": "Можливості",
+        "startStreamBtn": "Почати трансляцію"
+      },
+
+      "page404": {
+        "pageTitle": "Помилка",
+        "message": "Упс.. 404.. Дію не знайдено"
+      },
+
+      "page500": {
+        "pageTitle": "Помилка",
+        "message": "Упс.. 500.. У додатку сталася помилка"
+      }
+    },
+
+    "friends": {
+      "AllFriendsOffline": "Всі ваші друзі офлайн"
+    },
+
+    "streamWindow": {
+      "pageTitle": "Трансляція",
+      "endStreamConfirmMessage": "Ви впевнені, що хочете завершити свою трансляцію?",
+      "estimatedWaitingTimeMessage": "Очікуваний час очікування в черзі:",
+      "timeHours": "год(ин)",
+      "timeMinutes": "хвилин(и)",
+      "timeSeconds": "секунд(и)",
+      "loadingStreamTitle": "Завантаження...",
+      "gettingStreamReadyMessage": "Ми готуємо вашу трансляцію...",
+      "endStreamBtn": "Завершити трансляцію",
+      "disconnectBtn": "Від'єднатися",
+      "menuBtn": "Меню",
+      "menuTitle": "Відкрити меню Xbox",
+      "micMuted": "Вимкнено",
+      "micActive": "Увімкнено",
+      "enableMic": "Увімкнути мікрофон",
+      "disableMic": "Вимкнути мікрофон",
+      "debugTitle": "Відлагодження",
+      "itsTakingALittleLonger": "Це займає трохи більше часу.. Ваша трансляція може скоро початися.",
+      "startingConnection": "Початок підключення...",
+      "connectingToConsole": "Підключення до консолі...",
+      "clientHasBeenDisconnected": "Клієнт був відключений."
+    },
+
+    "updater": {
+      "unableToCheckForUpdates": "Не вдалося перевірити наявність оновлень зараз. Спробуйте ще раз.",
+      "alreadyOnLatestVersion": "Ви вже використовуєте останню версію. Поточна версія:",
+      "newestVersion": "Остання версія:",
+      "newReleaseAvailable": "Доступне нове оновлення",
+      "installedVersion": "Встановлена версія:",
+      "latestVersion": "Остання версія:",
+      "downloadBtn": "Завантажити",
+      "laterBtn": "Пізніше",
+      "updateChecker": "Перевірка оновлень",
+      "closeBtn": "Закрити"
+    },
+
+    "errors": {
+      "failedToRetrieveUserProfile": "Помилка! Не вдалося отримати профіль користувача:",
+      "repositoryNotFound": "Помилка! URL репозиторію не знайдено у файлі package.json.",
+      "failedToRetrieveStreamingTokens": "Помилка! Не вдалося отримати токени потокової передачі:",
+      "errorAuthentificationUser": "Помилка автентифікації користувача. Деталі помилки:",
+      "errorGettingRedirectURI": "Помилка отримання URI перенаправлення. Деталі помилки:",
+      "authentificationCallbackIsNotDefined": "Помилка! Callback автентифікації не визначено. Деталі помилки:",
+      "sisuTokenIsMissing": "Помилка! Відсутній токен Sisu. Будь ласка, автентифікуйтеся спочатку.",
+      "failedToRetrieveWebTokens": "Помилка! Не вдалося отримати веб-токени:",
+      "chatSDPExchangeError": "Помилка обміну ChatSDP:",
+      "ICEExchangeError": "Помилка обміну ICE:",
+      "SDPExchangeError": "Помилка обміну SDP:",
+      "failedToStartStream": "Не вдалося запустити нову трансляцію. Подробиці об помилці:",
+      "unableToStartStreamSession": "Не вдалося почати сесію трансляції на консолі. Консоль не підключена до серверів Xbox. Це іноді трапляється, коли є оновлення або коли користувач не увійшов у систему на консолі. Будь ласка, виконайте жорстку перезагрузку консолі та спробуйте ще раз.",
+      "streamErrorResult": "Результат помилки трансляції:",
+      "details": "Подробиці:",
+      "failedToGetPlayerState": "Не вдалося отримати стан гравця. Подробиці про помилку:"
+    }
+  }
+}

--- a/packages/desktop/renderer/lib/i18n.ts
+++ b/packages/desktop/renderer/lib/i18n.ts
@@ -1,0 +1,38 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+
+// Import all JSON files from the languages directory
+function importAllLanguages(): Record<string, { translation: any }> {
+  const resources: Record<string, { translation: any }> = {};
+  // @ts-ignore
+  const context = require.context("../languages", false, /\.json$/);
+  context.keys().forEach((key: string) => {
+    // Get the file name without extension
+    const langCode = key.replace("./", "").replace(".json", "");
+    resources[langCode] = context(key);
+  });
+  return resources;
+}
+
+const resources = importAllLanguages();
+
+// Function to initialize i18n with language from settings
+export function initI18nWithLanguage(settings) {
+    console.log("[i18n] Initializing i18n with settings:", settings);
+  const initialLanguage = settings?.language || "en-US";
+  console.log("[i18n] Initializing i18n with language:", initialLanguage);
+  i18n.use(initReactI18next).init({
+    resources,
+    lng: initialLanguage,
+    fallbackLng: initialLanguage,
+    interpolation: {
+      escapeValue: false,
+    },
+  }).then(() => {
+    console.log("[i18n] i18n initialized. Current language:", i18n.language);
+  }).catch((err) => {
+    console.error("[i18n] i18n initialization error:", err);
+  });
+}
+
+export default i18n;

--- a/packages/desktop/renderer/pages/404.tsx
+++ b/packages/desktop/renderer/pages/404.tsx
@@ -1,14 +1,17 @@
 import React from 'react'
 import Head from 'next/head'
+import { useTranslation } from 'react-i18next'
 
 function Error404Page() {
+    const { t } = useTranslation()
+
     return (
         <React.Fragment>
             <Head>
-                <title>Greenlight - Error</title>
+                <title>Greenlight - {t("page.page404.title")}</title>
             </Head>
-      
-            <p>Oopsie 404.. Action not found</p>
+
+            <p>{t("page.page404.message")}</p>
         </React.Fragment>
     )
 }

--- a/packages/desktop/renderer/pages/500.tsx
+++ b/packages/desktop/renderer/pages/500.tsx
@@ -1,14 +1,17 @@
 import React from 'react'
 import Head from 'next/head'
+import { useTranslation } from 'react-i18next'
 
 function Error500Page() {
+    const { t } = useTranslation()
+
     return (
         <React.Fragment>
             <Head>
-                <title>Greenlight - Error</title>
+                <title>Greenlight - {t("page500.pageTitle")}</title>
             </Head>
 
-            <p>Oopsie 500.. Application has an error</p>
+            <p>{t("page500.message")}</p>
         </React.Fragment>
     )
 }

--- a/packages/desktop/renderer/pages/_app.tsx
+++ b/packages/desktop/renderer/pages/_app.tsx
@@ -8,8 +8,10 @@ import Header from '../components/header'
 import Footer from '../components/footer'
 import Auth from '../components/auth'
 import SidebarFriends from '../components/sidebar/friends'
+import '../lib/i18n'
 
 import { UserProvider } from '../context/userContext'
+import { LanguageProvider } from '../context/languageContext'
 
 import {
     QueryClient,
@@ -49,13 +51,21 @@ export default function MyApp({ Component, pageProps }) {
             console.log('Requesting AuthState...')
             Ipc.send('app', 'getAuthState').then((args) => {
                 console.log('Received AuthState:', args)
-        
+
                 if(args.isAuthenticating === true){
                     setIsLoading(true)
                     setPrevUserState({ ...prevUserState, ...args.user})
 
                 } else if(args.isAuthenticated === true && args.user.signedIn === true){
                     clearInterval(authInterval)
+
+                    // After successful authentication, load and apply language setting
+                    Ipc.send('settings', 'getSettings').then(settings => {
+                        if (settings.language) {
+                            const i18n = require('../lib/i18n').default;
+                            i18n.changeLanguage(settings.language);
+                        }
+                    });
 
                     if(loggedIn === false){
                         Ipc.send('app', 'onUiShown').then((result) => {
@@ -65,7 +75,7 @@ export default function MyApp({ Component, pageProps }) {
                                 }, 1000)
                         })
                     }
-          
+
                     setLoginState(true)
                     setPrevUserState({ ...prevUserState, ...args.user})
                 }
@@ -127,7 +137,7 @@ export default function MyApp({ Component, pageProps }) {
             <Head>
                 <title>Greenlight</title>
             </Head>
-      
+
             <div style={ {
                 background: 'linear-gradient(0deg, rgba(26,27,30,1) 0%, rgba(26,27,30,1) 25%, rgba(0,212,255,0) 100%), url(\'/images/backgrounds/background1.jpeg\') fixed',
                 backgroundPosition: 'center',
@@ -137,9 +147,11 @@ export default function MyApp({ Component, pageProps }) {
                 height: '100vh',
             }}>
                 <QueryClientProvider client={queryClient}>
-                    <UserProvider>
-                        {appBody}
-                    </UserProvider>
+                    <LanguageProvider>
+                        <UserProvider>
+                            {appBody}
+                        </UserProvider>
+                    </LanguageProvider>
                 </QueryClientProvider>
             </div>
         </React.Fragment>

--- a/packages/desktop/renderer/pages/home.tsx
+++ b/packages/desktop/renderer/pages/home.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import Image from 'next/image'
 import Ipc from '../lib/ipc'
 import { useQuery } from 'react-query'
+import { useTranslation } from 'react-i18next'
 
 import Button from '../components/ui/button'
 import Card from '../components/ui/card'
@@ -12,11 +13,12 @@ import Loader from '../components/ui/loader'
 
 function Home() {
     const consoles = useQuery('consoles', () => Ipc.send('consoles', 'get'), { staleTime: 60*1000 })
-  
+    const { t } = useTranslation()
+
     return (
         <React.Fragment>
             <Head>
-                <title>Greenlight - My Consoles</title>
+                <title>Greenlight - {t('page.myConsoles.pageTitle')}</title>
             </Head>
 
             <div style={ {
@@ -27,7 +29,7 @@ function Home() {
                 paddingTop: '20px',
             }}>
                 { (consoles.isLoading === true) ? <Loader></Loader> :
-                    (consoles.isFetched === true && consoles.data.length > 0) ? consoles.data.map((item, i) => {               
+                    (consoles.isFetched === true && consoles.data.length > 0) ? consoles.data.map((item, i) => {
                         return (
                             <Card className='padbottom' key={i}>
                                 <h1>{item.name}</h1>
@@ -51,30 +53,30 @@ function Home() {
                                 <br />
 
                                 {(item.remoteManagementEnabled === true && item.consoleStreamingEnabled === true) ?
-                                    (item.powerState === 'On' ? <Label className='green'>Powered on</Label> :
-                                        item.powerState === 'ConnectedStandby' ? <Label>Standby</Label> :
+                                    (item.powerState === 'On' ? <Label className='green'>{t('page.myConsoles.poweredOn')}</Label> :
+                                        item.powerState === 'ConnectedStandby' ? <Label>{t('page.myConsoles.standby')}</Label> :
                                             <Label>{item.powerState}</Label>) :
                                     (<div>
-                                        {!item.remoteManagementEnabled ? '' : <p><Label className='orange'>Warning</Label> Remote management not enabled</p>}
-                                        {!item.consoleStreamingEnabled ? '' : <p><Label className='orange'>Warning</Label> Console streaming not enabled</p>}
+                                        {!item.remoteManagementEnabled ? '' : <p><Label className='orange'>{t('page.myConsoles.warningLabel')}</Label> {t('page.myConsoles.managementWarning')}</p>}
+                                        {!item.consoleStreamingEnabled ? '' : <p><Label className='orange'>{t('page.myConsoles.warningLabel')}</Label> {t('page.myConsoles.streamingWarning')}</p>}
                                     </div>)}
 
                                 {/* <p>Name: {item.name}</p>
-              <p>ID: {item.id}</p>
-              <p>State: {item.powerState}</p>
-              <p>Type: {item.consoleType}</p>
-              <p>Assistant: {item.digitalAssistantRemoteControlEnabled ? 'Enabled' : 'Disabled'}</p>
-              <p>Remote: {item.remoteManagementEnabled ? 'Enabled' : 'Disabled'}</p>
-              <p>Streaming: {item.consoleStreamingEnabled ? 'Enabled' : 'Disabled'}</p><br /> */}
+                                <p>ID: {item.id}</p>
+                                <p>State: {item.powerState}</p>
+                                <p>Type: {item.consoleType}</p>
+                                <p>Assistant: {item.digitalAssistantRemoteControlEnabled ? 'Enabled' : 'Disabled'}</p>
+                                <p>Remote: {item.remoteManagementEnabled ? 'Enabled' : 'Disabled'}</p>
+                                <p>Streaming: {item.consoleStreamingEnabled ? 'Enabled' : 'Disabled'}</p><br /> */}
 
                                 <div style={ { display: 'flex', gap: '20px', minWidth: 280 }}>
                                     <Link href={ `stream/${item.id}` }>
-                                        <Button label="Start stream" className='btn-primary' />
+                                        <Button label={t('page.myConsoles.startStreamBtn')} className='btn-primary' />
                                     </Link>
                                 </div>
                             </Card>
-                        ) 
-                    }) : <Card className='padbottom' key='noconsoles'>No consoles found on your account. If you do have an Xbox console then make sure that remote playing is enabled and that the console is visible in the official Xbox App.</Card>
+                        )
+                    }) : <Card className='padbottom' key='noconsoles'>{t('page.myConsoles.noConsoles')}</Card>
                 }
             </div>
 

--- a/packages/desktop/renderer/pages/settings/debug.tsx
+++ b/packages/desktop/renderer/pages/settings/debug.tsx
@@ -3,8 +3,10 @@ import Head from 'next/head'
 import Ipc from '../../lib/ipc'
 import Card from '../../components/ui/card'
 import SettingsSidebar from '../../components/settings/sidebar'
+import { useTranslation } from 'react-i18next'
 
 function SettingsDebug() {
+    const { t } = useTranslation()
     const [appDebug, setAppDebug] = React.useState([])
 
     React.useEffect(() => {
@@ -18,7 +20,7 @@ function SettingsDebug() {
     return (
         <React.Fragment>
             <Head>
-                <title>Greenlight - Settings: Debug</title>
+                <title>Greenlight - {t('settings.debug.pageTitle')}</title>
             </Head>
 
             <SettingsSidebar>
@@ -45,7 +47,7 @@ function SettingsDebug() {
                     }
                 </div>
             </SettingsSidebar>
-      
+
 
         </React.Fragment>
     )

--- a/packages/desktop/renderer/pages/settings/home.tsx
+++ b/packages/desktop/renderer/pages/settings/home.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
+import LanguageSelector from '../../components/settings/LanguageSelector'
 import Head from 'next/head'
 import Link from 'next/link'
 import Ipc from '../../lib/ipc'
@@ -20,6 +22,7 @@ interface userData {
 
 function SettingsHome() {
     const [user, setUser] = React.useState<userData>({})
+    const { t } = useTranslation()
 
     React.useEffect(() => {
         if(Object.keys(user).length === 0){
@@ -28,10 +31,10 @@ function SettingsHome() {
                 setUser(user)
             })
         }
-    })
+    }, [user])
 
     function logout(){
-        if(confirm('Are you sure you want to logout?')){
+        if(confirm(t('settings.about.logoutQuestion'))){
             Ipc.send('app', 'clearData')
         }
     }
@@ -39,7 +42,7 @@ function SettingsHome() {
     return (
         <React.Fragment>
             <Head>
-                <title>Greenlight - Settings</title>
+                <title>Greenlight - {t('settings.about.title')}</title>
             </Head>
 
             <SettingsSidebar>
@@ -57,10 +60,10 @@ function SettingsHome() {
                         <div className="component_auth_profile_userdetails">
                             <h1 style={{ paddingBottom: 5 }}>{ user.gamertag }</h1>
                             <p>
-                  Gamerscore: { user.gamerscore }
+                                {t('settings.about.gamerscore')}: { user.gamerscore }
                             </p>
-                            <Button label="Logout" className='btn' disabled={(window.Greenlight.isWebUI() === false) ? false : true } onClick={ () => {
-                                logout() 
+                            <Button label={t('settings.about.logout')} className='btn' disabled={(window.Greenlight.isWebUI() === false) ? false : true } onClick={ () => {
+                                logout()
                             } }></Button>
                         </div>
 
@@ -68,21 +71,24 @@ function SettingsHome() {
                     </div>
                 </Card>
 
+                <LanguageSelector />
+
                 <Card>
                     <div style={{ textAlign: 'center' }}>
                         <Image src={ GreenlightLogo } width="100" height="100" alt="Greenlight" />
 
                         <h2>Greenlight</h2>
                         <p>
-                    Version: { window.Greenlight.getVersion() }<br /><br />
-                            <small>Website: <Link href="#" title="Open link in external browser" onClick={ () => {
+                            {t('settings.about.version')}: { window.Greenlight.getVersion() }<br /><br />
+                            <small>{t('settings.about.website')}: <Link href="#" title={t('settings.about.websiteLinkTitle')} onClick={ () => {
                                 window.Greenlight.openExternal('https://github.com/unknownskl/greenlight')
-                            }}>github.com/unknownskl/greenlight</Link></small>
+                            }}>github.com/unknownskl/greenlight</Link></small><br />
+                            <small>{t('authorOfLocalization')}</small>
                         </p>
                     </div>
                 </Card>
             </SettingsSidebar>
-      
+
 
         </React.Fragment>
     )

--- a/packages/desktop/renderer/pages/settings/input.tsx
+++ b/packages/desktop/renderer/pages/settings/input.tsx
@@ -6,6 +6,8 @@ import Card from '../../components/ui/card'
 
 import { useSettings } from '../../context/userContext'
 
+import { useTranslation } from 'react-i18next'
+
 function invert(obj) {
     const new_obj = {}
     for (const prop in obj) {
@@ -15,6 +17,7 @@ function invert(obj) {
 }
 
 function KeySettings({keyConfigs, setKeyConfig}) {
+    const { t } = useTranslation()
     const mappableButtons = ['DPadUp', 'DPadDown', 'DPadLeft', 'DPadRight', 'A', 'B', 'X', 'Y', 'View', 'Menu', 'Nexus', 'LeftShoulder', 'RightShoulder', 'LeftTrigger', 'RightTrigger', 'LeftThumb', 'RightThumb']
     // console.log('KEYS:', keyConfigs, mappableButtons)
     keyConfigs = invert(keyConfigs)
@@ -26,35 +29,43 @@ function KeySettings({keyConfigs, setKeyConfig}) {
 
                     switch(btn){
                         case 'DPadUp':
-                            fullBtnText = 'DPad Up'
+                            fullBtnText = t('settings.input.dPadUp')
                             break
                         case 'DPadDown':
-                            fullBtnText = 'DPad Down'
+                            fullBtnText = t('settings.input.dPadDown')
                             break
                         case 'DPadLeft':
-                            fullBtnText = 'DPad Left'
+                            fullBtnText = t('settings.input.dPadLeft')
                             break
                         case 'DPadRight':
-                            fullBtnText = 'DPad Right'
+                            fullBtnText = t('settings.input.dPadRight')
                             break
                         case 'LeftShoulder':
-                            fullBtnText = 'Left Shoulder'
+                            fullBtnText = t('settings.input.leftShoulder')
                             break
                         case 'RightShoulder':
-                            fullBtnText = 'Right Shoulder'
+                            fullBtnText = t('settings.input.rightShoulder')
                             break
                         case 'LeftTrigger':
-                            fullBtnText = 'Left Trigger'
+                            fullBtnText = t('settings.input.leftTrigger')
                             break
                         case 'RightTrigger':
-                            fullBtnText = 'Right Trigger'
+                            fullBtnText = t('settings.input.rightTrigger')
                             break
                         case 'LeftThumb':
-                            fullBtnText = 'Left Thumbstick'
+                            fullBtnText = t('settings.input.leftThumb')
                             break
                         case 'RightThumb':
-                            fullBtnText = 'Right Thumbstick'
+                            fullBtnText = t('settings.input.rightThumb')
                             break
+                        case 'View':
+                            fullBtnText = t('settings.input.view')
+                            break
+                        case 'Menu':
+                            fullBtnText = t('settings.input.menu')
+                            break
+                        case 'Nexus':
+                            fullBtnText = t('settings.input.nexus')
                         default:
                             fullBtnText = btn
                             break
@@ -63,7 +74,7 @@ function KeySettings({keyConfigs, setKeyConfig}) {
                     return <p key={btn}>
                         <label>{fullBtnText}</label>
                         <label style={{minWidth: 0}}>
-                            <input type='text' className='text' onKeyUp={(e) => setKeyConfig(btn, e)} value={keyConfigs[btn] ?? 'None'}/>
+                            <input type='text' className='text' onKeyUp={(e) => setKeyConfig(btn, e)} value={keyConfigs[btn] ?? t('settings.input.none')}/>
                         </label>
                     </p>
                 }
@@ -77,6 +88,8 @@ function SettingsInput() {
     const [ controllerPing, setControllerPing] = React.useState(0)
 
     const [controllerKeys, setControllerKeys] = React.useState(settings.input_mousekeyboard_config)
+
+    const { t } = useTranslation()
 
     React.useEffect(() => {
         console.log('Last controller check:', controllerPing)
@@ -144,50 +157,48 @@ function SettingsInput() {
     return (
         <React.Fragment>
             <Head>
-                <title>Greenlight - Settings: Input</title>
+                <title>Greenlight - {t('settings.input.pageTitle')}</title>
             </Head>
 
             <SettingsSidebar>
                 <Card>
-                    <h1>Input</h1>
+                    <h1>{t('settings.input.title')}</h1>
 
                     <p>
-                        <label>Enable vibration</label>
+                        <label>{t('settings.input.enableVibration')}</label>
                         <label style={{ minWidth: 0 }}>
-                            <input type='checkbox' onChange={ setControllerVibration } checked={settings.controller_vibration} />&nbsp; ({ settings.controller_vibration ? 'Enabled' : 'Disabled'})
+                            <input type='checkbox' onChange={ setControllerVibration } checked={settings.controller_vibration} />&nbsp; ({ settings.controller_vibration ? t('settings.input.enabledLabel') : t('settings.input.disabledLabel')})
                         </label>
                     </p>
 
                     <p>
-                        <label>Enable Touch input</label>
+                        <label>{t('settings.input.enableTouch')}</label>
                         <label style={{ minWidth: 0 }}>
-                            <input type='checkbox' onChange={ setTouchInput } checked={settings.input_touch} />&nbsp; ({ settings.input_touch ? 'Enabled' : 'Disabled'})
+                            <input type='checkbox' onChange={ setTouchInput } checked={settings.input_touch} />&nbsp; ({ settings.input_touch ? t('settings.input.enabledLabel') : t('settings.input.disabledLabel')})
                         </label>
                     </p>
 
                     <p>
-                        <label>Enable Mouse & Keyboard</label>
+                        <label>{t('settings.input.enableMouseKeyboard')}</label>
                         <label style={{ minWidth: 0 }}>
-                            <input type='checkbox' onChange={ setMKBInput } checked={settings.input_mousekeyboard} />&nbsp; ({ settings.input_mousekeyboard ? 'Enabled' : 'Disabled'})
+                            <input type='checkbox' onChange={ setMKBInput } checked={settings.input_mousekeyboard} />&nbsp; ({ settings.input_mousekeyboard ? t('settings.input.enabledLabel') : t('settings.input.disabledLabel')})
                         </label> <br />
-                        { (!settings.input_newgamepad && settings.input_mousekeyboard) ? <small style={{ color: 'orange' }}>Using the Mouse & Keyboard driver together with the Gamepad keyboard mappings will cause conflicts</small> : '' }
+                        { (!settings.input_newgamepad && settings.input_mousekeyboard) ? <small style={{ color: 'orange' }}>{t('settings.input.legacyWarning')}</small> : '' }
                     </p>
 
                     <p>
-                        <label>Enable Keyboard to Gamepad</label>
+                        <label>{t('settings.input.enableLegacy')}</label>
                         <label style={{ minWidth: 0 }}>
-                            <input type='checkbox' onChange={ setLegacyInput } checked={!settings.input_newgamepad} />&nbsp; ({ !settings.input_newgamepad ? 'Enabled' : 'Disabled'})
+                            <input type='checkbox' onChange={ setLegacyInput } checked={!settings.input_newgamepad} />&nbsp; ({ !settings.input_newgamepad ? t('settings.input.enabledLabel') : t('settings.input.disabledLabel')})
                         </label><br />
-                        <small>(Disabling this feature will disable the keyboard to gamepad mapping and only allows controls from the gamepad.)</small>
+                        <small>{t('settings.input.enableLegacyDescription')}</small>
                     </p>
                 </Card>
 
                 <Card>
-                    <h1>Controllers detected</h1>
+                    <h1>{t('settings.input.controllerDetectedTitle')}</h1>
 
-                    <p>
-                        If you have a controller connected but it is not showing up, try to press a button on the controller to detect it.
-                    </p>
+                    <p>{t('settings.input.controllerDetectedDescription')}</p>
 
                     <div>
                         {
@@ -197,8 +208,8 @@ function SettingsInput() {
                                 #{ index+1 } &nbsp;
 
                                         { (item) ?
-                                            item.id + ' axes: ' + item.axes.length + ', buttons: ' + item.buttons.length + ', rumble: ' + ((item.vibrationActuator !== null) ? (item.vibrationActuator as any).type : 'Not supported')
-                                            : 'No controller detected'
+                                            item.id + ' ' + t('settings.input.axesLabel') + ': ' + item.axes.length + ', ' + t('settings.input.buttonsLabel') + ': ' + item.buttons.length + ', ' + t('settings.input.rumbleLabel') + ': ' + ((item.vibrationActuator !== null) ? (item.vibrationActuator as any).type : t('settings.input.notSupportedLabel'))
+                                            : t('settings.input.noControllerDetected')
                                         }
                                     </p>
                                 )
@@ -208,7 +219,7 @@ function SettingsInput() {
                 </Card>
 
                 <Card hidden={ settings.input_newgamepad }>
-                    <h1>Keyboard mappings</h1>
+                    <h1>{t('settings.input.keyboardMappingsTitle')}</h1>
                     <p>
                         {
                             <KeySettings keyConfigs={controllerKeys} setKeyConfig={setKeyConfig} />
@@ -216,7 +227,7 @@ function SettingsInput() {
                     </p>
                 </Card>
             </SettingsSidebar>
-      
+
 
         </React.Fragment>
     )

--- a/packages/desktop/renderer/pages/settings/streaming.tsx
+++ b/packages/desktop/renderer/pages/settings/streaming.tsx
@@ -5,11 +5,14 @@ import SettingsSidebar from '../../components/settings/sidebar'
 import Card from '../../components/ui/card'
 import Ipc from '../../lib/ipc'
 
+import { useTranslation } from 'react-i18next'
+
 import { useSettings } from '../../context/userContext'
 
 
 function SettingsStreaming() {
     const { settings, setSettings} = useSettings()
+    const { t } = useTranslation()
 
     React.useEffect(() => {
     //
@@ -66,90 +69,99 @@ function SettingsStreaming() {
     return (
         <React.Fragment>
             <Head>
-                <title>Greenlight - Settings: Streaming</title>
+                <title>Greenlight - {t('settings.streaming.pageTitle')}</title>
             </Head>
 
             <SettingsSidebar>
                 <Card>
-                    <h1>Stream settings</h1>
+                    <h1>{t('settings.streaming.title')}</h1>
 
-                    <p>
-                xHome and xCloud do not support more than 20mbps by default. This setting does not override this limit.
-                    </p>
+                    <p>{t('settings.streaming.description')}</p>
                     <p>
 
-                        <label>xCloud streaming bitrate</label>
+                        <label>{t('settings.streaming.xCloudStreamingBitrateLabel')}</label>
                         <input type="range" min="0" max="40960" step="1024" value={settings.xcloud_bitrate} onChange={ setxCloudBitrate } />
-                ({ settings.xcloud_bitrate === 0 ? 'Unlimited / Off' : Math.floor(settings.xcloud_bitrate / 1024) + ' mbps' })
+                ({ settings.xcloud_bitrate === 0 ? t('settings.streaming.unlimitedLabel') : Math.floor(settings.xcloud_bitrate / 1024) + ' ' + t('settings.streaming.mbpsLabel') })
                     </p>
                     <p>
-                        <label>xHome streaming bitrate</label>
+                        <label>{t('settings.streaming.xHomeStreamingBitrateLabel')}</label>
                         <input type="range" min="0" max="40960" step="1024" value={settings.xhome_bitrate} onChange={ setxHomeBitrate } />
-                ({ settings.xhome_bitrate === 0 ? 'Unlimited / Off' : Math.floor(settings.xhome_bitrate / 1024) + ' mbps' })
+                ({ settings.xhome_bitrate === 0 ? t('settings.streaming.unlimitedLabel') : Math.floor(settings.xhome_bitrate / 1024) + ' ' + t('settings.streaming.mbpsLabel') })
                     </p>
 
                     <p>
-                        <label>Set H.264 Profile </label>
+                        <label>{t('settings.streaming.setH264ProfileLabel')}</label>
                         <select value={ (settings.video_profiles.length > 0) ? settings.video_profiles[0] : '' } onChange={ (e) => setVideoProfile(e.target.value) }>
-                            <option value="">Auto-Negotiate</option>
-                            <option value="4d">High</option>
-                            <option value="42e">Medium</option>
-                            <option value="420">Low</option>
+                            <option value="">{t('settings.streaming.setH264ProfileValueAuto')}</option>
+                            <option value="4d">{t('settings.streaming.setH264ProfileValueHigh')}</option>
+                            <option value="42e">{t('settings.streaming.setH264ProfileValueMedium')}</option>
+                            <option value="420">{t('settings.streaming.setH264ProfileValueLow')}</option>
                         </select>
                     </p>
 
                 </Card>
 
                 <Card>
-                    <h1>Force region</h1>
+                    <h1>{t('settings.streaming.forceRegionTitle')}</h1>
                     <p>
 
-                        <label>Set region:</label>
+                        <label>{t('settings.streaming.setRegionLabel')}</label>
                         <select value={ settings.force_region_ip || '' } onChange={ (e) => setForceRegionIp(e.target.value) }>
-                            <option value="">Disabled</option>
-                            <option value="203.41.44.20">Australia</option>
-                            <option value="200.221.11.101">Brazil</option>
-                            <option value="194.25.0.68">Europe</option>
-                            <option value="122.1.0.154">Japan</option>
-                            <option value="203.253.64.1">Korea</option>
-                            <option value="4.2.2.2">United States</option>
+                            <option value="">{t('settings.streaming.setRegionValueDisabled')}</option>
+                            <option value="203.41.44.20">{t('settings.streaming.setRegionValueAustralia')}</option>
+                            <option value="200.221.11.101">{t('settings.streaming.setRegionValueBrazil')}</option>
+                            <option value="194.25.0.68">{t('settings.streaming.setRegionValueEurope')}</option>
+                            <option value="122.1.0.154">{t('settings.streaming.setRegionValueJapan')}</option>
+                            <option value="203.253.64.1">{t('settings.streaming.setRegionValueKorea')}</option>
+                            <option value="4.2.2.2">{t('settings.streaming.setRegionValueUS')}</option>
                         </select>
                     </p>
                     <p>
-                        <label>Preferred game language:</label>
-                        <select value={settings.preferred_game_language || ''} onChange={(e) => setPreferredGameLanguage(e.target.value)}>
-                            <option value="ar-SA">Arabic (Saudi Arabia)</option>
-                            <option value="cs-CZ">Czech</option>
-                            <option value="da-DK">Danish</option>
-                            <option value="de-DE">German</option>
-                            <option value="el-GR">Greek</option>
-                            <option value="en-GB">English (United Kingdom)</option>
-                            <option value="en-US">English (United States)</option>
-                            <option value="es-ES">Spanish (Spain)</option>
-                            <option value="es-MX">Spanish (Mexico)</option>
-                            <option value="fi-FI">Swedish</option>
-                            <option value="fr-FR">French</option>
-                            <option value="he-IL">Hebrew</option>
-                            <option value="hu-HU">Hungarian</option>
-                            <option value="it-IT">Italian</option>
-                            <option value="ja-JP">Japanese</option>
-                            <option value="ko-KR">Korean</option>
-                            <option value="nb-NO">Norwegian</option>
-                            <option value="nl-NL">Dutch</option>
-                            <option value="pl-PL">Polish</option>
-                            <option value="pt-BR">Portuguese (Brazil)</option>
-                            <option value="pt-PT">Portuguese (Portugal)</option>
-                            <option value="ru-RU">Russian</option>
-                            <option value="sk-SK">Slovak</option>
-                            <option value="sv-SE">Swedish</option>
-                            <option value="tr-TR">Turkish</option>
-                            <option value="zh-CN">Chinese (PRC)</option>
-                            <option value="zh-TW">Chinese (Taiwan)</option>
-                        </select>
+                        <label>{t('settings.streaming.preferredGameLanguageLabel')}</label>
+                        {(() => {
+                            const languages = [
+                                { code: "ar-SA", label: t('settings.streaming.preferredGameLanguageValueArabic') },
+                                { code: "cs-CZ", label: t('settings.streaming.preferredGameLanguageValueCzech') },
+                                { code: "da-DK", label: t('settings.streaming.preferredGameLanguageValueDanish') },
+                                { code: "de-DE", label: t('settings.streaming.preferredGameLanguageValueGerman') },
+                                { code: "el-GR", label: t('settings.streaming.preferredGameLanguageValueGreek') },
+                                { code: "en-GB", label: t('settings.streaming.preferredGameLanguageValueEnglishUK') },
+                                { code: "en-US", label: t('settings.streaming.preferredGameLanguageValueEnglishUS') },
+                                { code: "es-ES", label: t('settings.streaming.preferredGameLanguageValueSpanish') },
+                                { code: "es-MX", label: t('settings.streaming.preferredGameLanguageValueSpanishMX') },
+                                { code: "fi-FI", label: t('settings.streaming.preferredGameLanguageValueFinnish') },
+                                { code: "fr-FR", label: t('settings.streaming.preferredGameLanguageValueFrench') },
+                                { code: "he-IL", label: t('settings.streaming.preferredGameLanguageValueHebrew') },
+                                { code: "hu-HU", label: t('settings.streaming.preferredGameLanguageValueHungarian') },
+                                { code: "it-IT", label: t('settings.streaming.preferredGameLanguageValueItalian') },
+                                { code: "ja-JP", label: t('settings.streaming.preferredGameLanguageValueJapanese') },
+                                { code: "ko-KR", label: t('settings.streaming.preferredGameLanguageValueKorean') },
+                                { code: "nb-NO", label: t('settings.streaming.preferredGameLanguageValueNorwegian') },
+                                { code: "nl-NL", label: t('settings.streaming.preferredGameLanguageValueDutch') },
+                                { code: "pl-PL", label: t('settings.streaming.preferredGameLanguageValuePolish') },
+                                { code: "pt-BR", label: t('settings.streaming.preferredGameLanguageValuePortugueseBR') },
+                                { code: "pt-PT", label: t('settings.streaming.preferredGameLanguageValuePortuguese') },
+                                { code: "ru-RU", label: t('settings.streaming.preferredGameLanguageValueRussian') },
+                                { code: "sk-SK", label: t('settings.streaming.preferredGameLanguageValueSlovak') },
+                                { code: "sv-SE", label: t('settings.streaming.preferredGameLanguageValueSwedish') },
+                                { code: "tr-TR", label: t('settings.streaming.preferredGameLanguageValueTurkish') },
+                                { code: "zh-CN", label: t('settings.streaming.preferredGameLanguageValueChineseCN') },
+                                { code: "zh-TW", label: t('settings.streaming.preferredGameLanguageValueChineseTW') },
+                            ];
+                            // Sort languages alphabetically by label
+                            const sortedLanguages = languages.sort((a, b) => a.label.localeCompare(b.label));
+                            return (
+                                <select value={settings.preferred_game_language || ''} onChange={(e) => setPreferredGameLanguage(e.target.value)}>
+                                    {sortedLanguages.map(lang => (
+                                        <option key={lang.code} value={lang.code}>{lang.label}</option>
+                                    ))}
+                                </select>
+                            );
+                        })()}
                     </p>
                 </Card>
             </SettingsSidebar>
-      
+
 
         </React.Fragment>
     )

--- a/packages/desktop/renderer/pages/settings/video.tsx
+++ b/packages/desktop/renderer/pages/settings/video.tsx
@@ -4,10 +4,12 @@ import SettingsSidebar from '../../components/settings/sidebar'
 import Card from '../../components/ui/card'
 import Ipc from '../../lib/ipc'
 import { useSettings } from '../../context/userContext'
+import { useTranslation } from 'react-i18next'
 
 
 function SettingsVideo() {
     const { settings, setSettings} = useSettings()
+    const { t } = useTranslation()
 
     React.useEffect(() => {
     //
@@ -47,52 +49,52 @@ function SettingsVideo() {
     return (
         <React.Fragment>
             <Head>
-                <title>Greenlight - Settings: Video & Audio</title>
+                <title>Greenlight - {t('settings.videoAudio.pageTitle')}</title>
             </Head>
 
             <SettingsSidebar>
                 <Card>
-                    <h1>Video</h1>
+                    <h1>{t('settings.videoAudio.title')}</h1>
 
                     <p>
-                        <label>Disable video</label>
+                        <label>{t('settings.videoAudio.disableVideoLabel')}</label>
                         <label style={{ minWidth: 0 }}>
-                            <input type='checkbox' onChange={ setVideoEnabled } checked={!settings.video_enabled} />&nbsp; ({ !settings.video_enabled ? 'Enabled' : 'Disabled'})
+                            <input type='checkbox' onChange={ setVideoEnabled } checked={!settings.video_enabled} />&nbsp; ({ !settings.video_enabled ? t('settings.videoAudio.enabledLabel') : t('settings.videoAudio.disabledLabel')})
                         </label>
                     </p>
 
                     <p>
-                        <label>Video aspect size</label>
+                        <label>{t('settings.videoAudio.aspectSizeLabel')}</label>
                         <select value={ settings.video_size } onChange={(e) => {
                             setVideoSize(e.target.value)
                         }}>
-                            <option value='default'>Default</option>
-                            <option value='stretch'>Stretch</option>
-                            <option value='zoom'>Zoom</option>
+                            <option value='default'>{t('settings.videoAudio.aspectSizeValueDefault')}</option>
+                            <option value='stretch'>{t('settings.videoAudio.aspectSizeValueStretch')}</option>
+                            <option value='zoom'>{t('settings.videoAudio.aspectSizeValueZoom')}</option>
                         </select>
                     </p>
 
                     <p>
-                        <label>Force low resolution video</label>
+                        <label>{t('settings.videoAudio.forceLowResLabel')}</label>
                         <label style={{ minWidth: 0 }}>
-                            <input type='checkbox' onChange={ forceLowResolution } checked={settings.app_lowresolution} />&nbsp; ({ settings.app_lowresolution ? 'Enabled' : 'Disabled'})
+                            <input type='checkbox' onChange={ forceLowResolution } checked={settings.app_lowresolution} />&nbsp; ({ settings.app_lowresolution ? t('settings.videoAudio.enabledLabel') : t('settings.videoAudio.disabledLabel')})
                         </label><br />
-                        <small>(This option is useful on the Steam Deck and enables the application to render in a low resolution so FSR can be enabled.)</small>
+                        <small>{t('settings.videoAudio.forceLowResDescription')}</small>
                     </p>
                 </Card>
 
                 <Card>
-                    <h1>Audio</h1>
+                    <h1>{t('settings.videoAudio.audioTitle')}</h1>
 
                     <p>
-                        <label>Disable audio</label>
+                        <label>{t('settings.videoAudio.disableAudioLabel')}</label>
                         <label style={{ minWidth: 0 }}>
-                            <input type='checkbox' onChange={ setAudioEnabled } checked={!settings.audio_enabled} />&nbsp; ({ !settings.audio_enabled ? 'Enabled' : 'Disabled'})
+                            <input type='checkbox' onChange={ setAudioEnabled } checked={!settings.audio_enabled} />&nbsp; ({ !settings.audio_enabled ? t('settings.videoAudio.enabledLabel') : t('settings.videoAudio.disabledLabel')})
                         </label>
                     </p>
                 </Card>
             </SettingsSidebar>
-      
+
 
         </React.Fragment>
     )

--- a/packages/desktop/renderer/pages/settings/webui.tsx
+++ b/packages/desktop/renderer/pages/settings/webui.tsx
@@ -5,11 +5,13 @@ import Card from '../../components/ui/card'
 import Button from '../../components/ui/button'
 import Ipc from '../../lib/ipc'
 import { useSettings } from '../../context/userContext'
+import { useTranslation } from 'react-i18next'
 
 
 function SettingsWebUI() {
     const { settings, setSettings} = useSettings()
     const [webuiRunning, setWebuiRunning] = React.useState(false)
+    const { t } = useTranslation()
 
     React.useEffect(() => {
         const webuiStatusInterval = setInterval(() => {
@@ -50,37 +52,37 @@ function SettingsWebUI() {
     return (
         <React.Fragment>
             <Head>
-                <title>Greenlight - Settings: Web UI</title>
+                <title>Greenlight - {t('settings.webUI.pageTitle')}</title>
             </Head>
 
             <SettingsSidebar>
                 <Card>
-                    <h1>WebUI</h1>
+                    <h1>{t('settings.webUI.title')}</h1>
 
                     <p>
-                        <label>Enable WebUI</label>
+                        <label>{t('settings.webUI.enableWebUILabel')}</label>
                         <label style={{ minWidth: 0 }}>
-                            <Button onClick={ () => setWebUIEnabled() } disabled={ window.Greenlight.isWebUI() } className={ ((webuiRunning) ? 'btn-primary' : 'btn-cancel') + ' btn-small' } label={ webuiRunning ? 'Stop Web UI' : 'Start Web UI' }></Button> &nbsp;
-                            <Button onClick={ () => window.Greenlight.openExternal('http://127.0.0.1:'+settings.webui_port) } className={ 'btn-small' } label={ 'Open Web UI' }></Button>
+                            <Button onClick={ () => setWebUIEnabled() } disabled={ window.Greenlight.isWebUI() } className={ ((webuiRunning) ? 'btn-cancel' : 'btn-primary') + ' btn-small' } label={ webuiRunning ? t('settings.webUI.stopWebUIBtn') : t('settings.webUI.startWebUIBtn') }></Button> &nbsp;
+                            <Button onClick={ () => window.Greenlight.openExternal('http://127.0.0.1:'+settings.webui_port) } className={ 'btn-small' } label={ t('settings.webUI.openWebUIBtn') }></Button>
                         </label>
                     </p>
 
                     <p>
-                        <label>Start WebUI on application start</label>
+                        <label>{t('settings.webUI.autostartLabel')}</label>
                         <label style={{ minWidth: 0 }}>
-                            <input type='checkbox' onChange={ setWebUIAutostart } checked={settings.webui_autostart} />&nbsp; ({ settings.webui_autostart ? 'Enabled' : 'Disabled'})
+                            <input type='checkbox' onChange={ setWebUIAutostart } checked={settings.webui_autostart} />&nbsp; ({ settings.webui_autostart ? t('settings.webUI.autostartEnabled') : t('settings.webUI.autostartDisabled') })
                         </label>
                     </p>
 
                     <p>
-                        <label>Port</label>
+                        <label>{t('settings.webUI.portLabel')}</label>
                         <label style={{ minWidth: 0 }}>
-                            <input type="text" onChange={ setWebUIPort} className="text" placeholder="example: 9003" value={ settings.webui_port || 9003 } />
+                            <input type="text" onChange={ setWebUIPort} className="text" placeholder={t('settings.webUI.portPlaceholder')} value={ settings.webui_port || 9003 } />
                         </label>
                     </p>
                 </Card>
             </SettingsSidebar>
-      
+
 
         </React.Fragment>
     )

--- a/packages/desktop/renderer/pages/stream/[serverid].tsx
+++ b/packages/desktop/renderer/pages/stream/[serverid].tsx
@@ -7,10 +7,12 @@ import { useSettings } from '../../context/userContext'
 import StreamComponent from '../../components/ui/streamcomponent'
 import StreamPreload from '../../components/ui/streampreload'
 import Ipc from '../../lib/ipc'
+import { useTranslation } from 'react-i18next'
 
 function Stream() {
     const router = useRouter()
     const { settings } = useSettings()
+    const { t } = useTranslation()
 
     let streamStateInterval
     let keepaliveInterval
@@ -49,10 +51,10 @@ function Stream() {
                     sdp: offer.sdp,
                 }).then((sdpResponse) => {
                     xPlayer.setRemoteOffer(sdpResponse.sdp)
-    
+
                 }).catch((error) => {
                     console.log('ChatSDP Exchange error:', error)
-                    alert('ChatSDP Exchange error:'+ JSON.stringify(error))
+                    alert(t('errors.chatSDPExchangeError') + ' ' + JSON.stringify(error))
                 })
             })
 
@@ -85,34 +87,34 @@ function Stream() {
 
                     }).catch((error) => {
                         console.log('ICE Exchange error:', error)
-                        alert('ICE Exchange error:'+ JSON.stringify(error))
+                        alert(t('errors.ICEExchangeError') + ' ' + JSON.stringify(error))
                     })
 
                 }).catch((error) => {
                     console.log('SDP Exchange error:', error)
-                    alert('SDP Exchange error:'+ JSON.stringify(error))
+                    alert(t('errors.SDPExchangeError') + ' ' + JSON.stringify(error))
                 })
             })
-    
+
             xPlayer.getEventBus().on('connectionstate', (event) => {
                 console.log('connectionstate changed:', event)
-    
+
                 const connStatus = document.getElementById('component_streamcomponent_connectionstatus')
                 if(connStatus !== null){
                     if(event.state === 'connected'){
-                        connStatus.innerText = 'Client has been connected!'
+                        connStatus.innerText = t('streamWindow.clientHasBeenDisconnected')
                         document.getElementById('component_streamcomponent_loader').className = 'hidden'
-    
+
                         // Set audio / Video settings
                         // @TODO: Implement api's in xbox-xcloud-player
                         if(settings.audio_enabled === false){
                             xPlayer._audioComponent._audioRender.muted = true
                         }
-    
+
                         if(settings.video_enabled === false){
                             xPlayer._videoComponent._videoRender.style.opacity = 0
                         }
-    
+
                         // Start keepalive loop
                         keepaliveInterval = setInterval(() => {
                             Ipc.send('streaming', 'sendKeepalive', {
@@ -123,13 +125,13 @@ function Stream() {
                                 console.error('Failed to send keepalive. Error details:\n'+JSON.stringify(error))
                             })
                         }, 30000) // Send every 30 seconds
-    
+
                     } else if(event.state === 'new'){
-                        connStatus.innerText = 'Starting connection...'
-    
+                        connStatus.innerText = t('streamWindow.startingConnection')
+
                     } else if(event.state === 'connecting'){
-                        connStatus.innerText = 'Connecting to console...'
-    
+                        connStatus.innerText = t('streamWindow.connectingToConsole')
+
                     } else if(event.state === 'closed') {
                         // Client has been disconnected. Lets return to home.
                         // xPlayer.close()
@@ -147,9 +149,9 @@ function Stream() {
             }).then((result:string) => {
                 console.log('StartStream session:', result)
                 setSessionId(result)
-    
+
             }).catch((error) => {
-                alert('Failed to start new stream. Error details:\n'+JSON.stringify(error))
+                alert(t('errors.failedToStartStream') + '\n' + JSON.stringify(error))
             })
         } else {
 
@@ -167,7 +169,7 @@ function Stream() {
                         case 'started':
                             // Console is ready
                             clearInterval(streamStateInterval)
-                            
+
                             // Start xPlayer interface
                             setxPlayer(new xCloudPlayer('streamComponent', {
                                 ui_systemui: [],
@@ -186,9 +188,9 @@ function Stream() {
 
                             if(session.errorDetails.code === 'WNSError' && session.errorDetails.message.includes('WaitingForServerToRegister')){
                                 // Detected the "WaitingForServerToRegister" error. This means the console is not connected to the xbox servers
-                                alert('Unable to start stream session on console. The console is not connected to the Xbox servers. This occasionally happens when there is an update or when the user is not signed in to the console. Please hard reboot your console and try again.\n\n'+'Stream error result: '+session.state+'\nDetails: ['+session.errorDetails.code+'] '+session.errorDetails.message)
+                                alert(t('errors.unableToStartStreamSession') + '\n\n' + t('errors.streamErrorResult') + ' ' + session.state + '\n' + t('errors.details') + ' [' + session.errorDetails.code + '] ' + session.errorDetails.message)
                             } else {
-                                alert('Stream error result: '+session.state+'\nDetails: ['+session.errorDetails.code+'] '+session.errorDetails.message)
+                                alert(t('errors.streamErrorResult') + ' ' + session.state + '\n' + t('errors.details') + ' [' + session.errorDetails.code + '] ' + session.errorDetails.message)
                             }
                             console.log('Full stream error:', session.errorDetails)
                             onDisconnect()
@@ -202,13 +204,13 @@ function Stream() {
                                 setQueueTime(session.waitingTimes.estimatedTotalWaitTimeInSeconds)
                                 console.log('Setting queue to:', session.waitingTimes.estimatedTotalWaitTimeInSeconds)
 
-                                
+
                             }
                             break
                     }
 
                 }).catch((error) => {
-                    alert('Failed to get player state. Error details:\n'+JSON.stringify(error))
+                    alert(t('errors.failedToGetPlayerState') + '\n' + JSON.stringify(error))
                 })
             }, 1000)
         }
@@ -220,11 +222,11 @@ function Stream() {
             }
 
             if(keepaliveInterval){
-                clearInterval(keepaliveInterval) 
+                clearInterval(keepaliveInterval)
             }
 
             if(streamStateInterval){
-                clearInterval(streamStateInterval) 
+                clearInterval(streamStateInterval)
             }
         }
     })
@@ -234,7 +236,7 @@ function Stream() {
         xPlayer.getChannelProcessor('input').pressButton(0, 'Nexus')
     }
 
-    function onDisconnect(){  
+    function onDisconnect(){
         Ipc.send('streaming', 'stopStream', {
             sessionId: sessionId,
         }).then((result) => {
@@ -249,17 +251,17 @@ function Stream() {
     return (
         <React.Fragment>
             <Head>
-                <title>Greenlight - Streaming {router.query.serverid}</title>
+                <title>Greenlight - {t('streamWindow.pageTitle')} {router.query.serverid}</title>
             </Head>
 
             { (xPlayer !== undefined) ? <StreamComponent onDisconnect={ () => {
-                onDisconnect() 
+                onDisconnect()
             }} onMenu={ () => {
-                gamepadSend('nexus') 
+                gamepadSend('nexus')
             } } xPlayer={ xPlayer }></StreamComponent> : (queueTime > 0) ?<StreamPreload onDisconnect={ () => {
-                onDisconnect() 
+                onDisconnect()
             }} waitingTime={ queueTime }></StreamPreload> : <StreamPreload onDisconnect={ () => {
-                onDisconnect() 
+                onDisconnect()
             }}></StreamPreload> }
         </React.Fragment>
     )

--- a/packages/desktop/renderer/pages/xcloud/home.tsx
+++ b/packages/desktop/renderer/pages/xcloud/home.tsx
@@ -6,8 +6,10 @@ import Button from '../../components/ui/button'
 import BreadcrumbBar from '../../components/ui/breadcrumbbar'
 import TitleRow from '../../components/xcloud/titleRow'
 import { useQuery } from 'react-query'
+import { useTranslation } from 'react-i18next'
 
 function xCloudHome() {
+    const { t } = useTranslation()
     useQuery('xCloudTitles', () => Ipc.send('xCloud', 'getTitles'), { staleTime: 300*1000 })
     const xCloudNewTitles = useQuery('xCloudNewTitles', () => Ipc.send('xCloud', 'getNewTitles'), { staleTime: 60*1000 })
     const xCloudRecentTitles = useQuery('xCloudRecentTitles', () => Ipc.send('xCloud', 'getRecentTitles'), { staleTime: 10*1000 })
@@ -15,21 +17,21 @@ function xCloudHome() {
     return (
         <React.Fragment>
             <Head>
-                <title>Greenlight - xCloud Library</title>
+                <title>Greenlight - {t('page.xCloud.pageTitle')}</title>
             </Head>
 
             <BreadcrumbBar>
-                <Link href="/xcloud/home">xCloud</Link>
+                <Link href="/xcloud/home">{t('page.xCloud.breadcrumb')}</Link>
                 {/* <Link href="/xcloud/library">Library</Link> */}
             </BreadcrumbBar>
 
-            <TitleRow titles={ (xCloudRecentTitles.isFetched) ? xCloudRecentTitles.data : [] }>Recent Games</TitleRow>
+            <TitleRow titles={ (xCloudRecentTitles.isFetched) ? xCloudRecentTitles.data : [] }>{t('page.xCloud.recentGames')}</TitleRow>
 
             <TitleRow titles={ (xCloudNewTitles.isFetched) ? xCloudNewTitles.data : [] }>
-          Recently added &nbsp;
-                <Link href="/xcloud/library"><Button label="View Library" className='btn-small'></Button></Link>
+                {t('page.xCloud.recentlyAdded')}&nbsp;
+                <Link href="/xcloud/library"><Button label={t('page.xCloud.viewLibraryBtn')} className='btn-small'></Button></Link>
             </TitleRow>
-        
+
             {/* } */}
 
         </React.Fragment>

--- a/packages/desktop/renderer/pages/xcloud/info/[titleid].tsx
+++ b/packages/desktop/renderer/pages/xcloud/info/[titleid].tsx
@@ -8,6 +8,7 @@ import BreadcrumbBar from '../../../components/ui/breadcrumbbar'
 import Button from '../../../components/ui/button'
 import Loader from '../../../components/ui/loader'
 import { useQuery } from 'react-query'
+import { useTranslation } from 'react-i18next'
 
 
 
@@ -15,6 +16,7 @@ function xCloudInfo() {
     const router = useRouter()
     const productDetails = useQuery('xcloudinfo_titleId_'+router.query.titleid, () => Ipc.send('xCloud', 'getTitle', { titleId: router.query.titleid}), { staleTime: 10*1000 })
     const [productName, setProductName] = React.useState('...')
+    const { t } = useTranslation()
 
     if(productDetails.isFetched === true && productName === '...')
         setProductName(productDetails.data.catalogDetails.ProductTitle)
@@ -22,12 +24,12 @@ function xCloudInfo() {
     return (
         <React.Fragment>
             <Head>
-                <title>Greenlight - Viewing title information: { router.query.titleid }</title>
+                <title>Greenlight - {t('page.titleInfo.pageTitle')} { router.query.titleid }</title>
             </Head>
 
             <BreadcrumbBar>
-                <Link href="/xcloud/home">xCloud</Link>
-                <Link href="/xcloud/library">Library</Link>
+                <Link href="/xcloud/home">{t('page.titleInfo.breadcrumb1')}</Link>
+                <Link href="/xcloud/library">{t('page.titleInfo.breadcrumb2')}</Link>
                 <Link href={ '/xcloud/info/'+router.query.titleid }>{productName}</Link>
             </BreadcrumbBar>
 
@@ -38,12 +40,12 @@ function xCloudInfo() {
                     backgroundRepeat: 'no-repeat',
                     backgroundSize: 'cover',
                 }}></div>
-          
+
                 <div id="page_info_titleid">
 
                     <div id="page_info_hero">
                         <h1>{productName}</h1>
-                        <h2>by { productDetails.data.catalogDetails.PublisherName }</h2>
+                        <h2>{t('page.titleInfo.by')} { productDetails.data.catalogDetails.PublisherName }</h2>
                     </div>
 
                     <div id="page_info_titleid_sidebar">
@@ -51,18 +53,18 @@ function xCloudInfo() {
                         <br />
 
                         <Link href={ '/stream/xcloud_'+router.query.titleid }>
-                            <Button label={ 'Stream Game' } className='btn-primary'></Button>
+                            <Button label={ t('page.titleInfo.startStreamBtn') } className='btn-primary'></Button>
                         </Link>
                     </div>
 
                     <div id="page_info_titleid_content">
-                        <h3>Description</h3>
+                        <h3>{t('page.titleInfo.descriptionTitle')}</h3>
 
                         <p>
                             { productDetails.data.catalogDetails.ProductDescriptionShort }
                         </p>
 
-                        <h3>Capabilities</h3>
+                        <h3>{t('page.titleInfo.capabilitiesTitle')}</h3>
 
                         <div>
                             {productDetails.data.catalogDetails.Attributes.map((item) => {

--- a/packages/desktop/renderer/pages/xcloud/library.tsx
+++ b/packages/desktop/renderer/pages/xcloud/library.tsx
@@ -7,9 +7,11 @@ import ViewportGrid from '../../components/ui/viewportgrid'
 import GameTitleDynamic from '../../components/ui/game/titledynamic'
 import BreadcrumbBar from '../../components/ui/breadcrumbbar'
 import { useQuery, QueryClient } from 'react-query'
+import { useTranslation } from 'react-i18next'
 
 
 function xCloudLibrary() {
+    const { t } = useTranslation()
     const [filter, setFilter] = React.useState({
         name: '',
     })
@@ -34,18 +36,18 @@ function xCloudLibrary() {
     return (
         <React.Fragment>
             <Head>
-                <title>Greenlight - xCloud Library</title>
+                <title>Greenlight - {t('page.xCloudLibrary.pageTitle')}</title>
             </Head>
 
             <BreadcrumbBar>
-                <Link href="/xcloud/home">xCloud</Link>
-                <Link href="/xcloud/library">Library</Link>
+                <Link href="/xcloud/home">{t('page.xCloudLibrary.breadcrumb1')}</Link>
+                <Link href="/xcloud/library">{t('page.xCloudLibrary.breadcrumb2')}</Link>
             </BreadcrumbBar>
 
             <h2 className="title">
-        Library
+                {t('page.xCloudLibrary.title')}
 
-                <input type="text" className="text h2-search" placeholder="Search" onChange={
+                <input type="text" className="text h2-search" placeholder={t('page.xCloudLibrary.searchPlaceholder')} onChange={
                     (e) => {
                         setFilter({
                             name: e.target.value,
@@ -53,7 +55,7 @@ function xCloudLibrary() {
                     }
                 }></input>
             </h2>
-      
+
             <ViewportGrid key='library' drawPagination={true}>{
                 (xCloudTitles.isFetched !== true) ? (<Loader></Loader>) : performFilter().map((item) => {
                     return (


### PR DESCRIPTION
**Add full multilingual support**

This PR introduces multilingual support for the application:

* Initial translations: English (default), Russian, and Ukrainian have been added.

* Adding new languages: To add a new language, create a JSON file with the ISO format name (e.g., `en-GB`, `uk-UA`) and place it in `packages/desktop/renderer/languages`. Inside the file, define:

    * `languageName` — the name of the language
    * `authorOfLocalization` — the author of the translation

* Language application timing: Currently, the selected language is applied only after user login. This is because application settings are loaded asynchronously at startup, and there is no mechanism yet to detect the user’s preferred language before the app fully loads.

* Game description and features: At the moment, the game’s description and feature information are fetched in English, regardless of the selected user language. To properly localize this:

    * In `packages/desktop/main/helpers/titlemanager.ts`, the `language` GET parameter should be set to the user’s language.

    * Optionally, the `market` parameter can be set to reflect country-specific information.

* Future improvements: Expand the game information fetched to include available in-game languages, supported platforms, and other metadata.

This PR lays the foundation for full multilingual support and allows further localization without changing core app code.

<img width="1465" height="1072" alt="image" src="https://github.com/user-attachments/assets/40fb4372-aa6d-454c-8ed9-92f581d795aa" />

<img width="1465" height="1072" alt="image" src="https://github.com/user-attachments/assets/f7fe0bb6-62a7-41e5-86ce-ff6e7cae50f6" />


