### PR TITLE
Add Dependabot automerge flows

### DIFF
--- a/.github/workflows/build_desktop.yml
+++ b/.github/workflows/build_desktop.yml
@@ -291,3 +291,36 @@ jobs:
           path: |
             packages/desktop/dist/*.exe
         if: matrix.os == 'windows-latest' && contains(github.event.head_commit.message, '[build]')
+
+  dependabot-merge:
+    name: "Dependabot Auto-Merge Check"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && github.event.pull_request.user.login == 'dependabot[bot]'
+    needs: [flatpak, release]
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+
+      - name: Merge when build succeeds
+        uses: actions/github-script@v7
+        with:
+          script: |
+            console.log('Build passed, automerging Dependabot PR...');
+
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              event: 'APPROVE',
+              body: 'Build passed, automerging Dependabot PR...',
+            });
+            console.log('Dependabot PR approved successfully.');
+
+            await github.rest.pulls.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              merge_method: 'merge',
+            });
+            console.log('Dependabot PR merged successfully.');

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -87,3 +87,36 @@ jobs:
 
       - name: Info
         run: echo "Deployed to ${{ steps.deployment-pages.outputs.page_url }}"
+
+  dependabot-merge:
+    name: "Dependabot Auto-Merge Check"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && github.event.pull_request.user.login == 'dependabot[bot]'
+    needs: [build]
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+
+      - name: Merge when build succeeds
+        uses: actions/github-script@v7
+        with:
+          script: |
+            console.log('Build passed, automerging Dependabot PR...');
+
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              event: 'APPROVE',
+              body: 'Build passed, automerging Dependabot PR...',
+            });
+            console.log('Dependabot PR approved successfully.');
+
+            await github.rest.pulls.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              merge_method: 'merge',
+            });
+            console.log('Dependabot PR merged successfully.');


### PR DESCRIPTION
This pull request introduces automation to auto-approve and auto-merge Dependabot pull requests when all required build jobs succeed. The workflow additions ensure that updates from Dependabot are merged quickly and safely, reducing manual intervention for dependency updates.

**Automation for Dependabot PRs:**

* Added a `dependabot-merge` job to `.github/workflows/build_desktop.yml` that automatically approves and merges Dependabot pull requests after the `flatpak` and `release` jobs succeed.
* Added a `dependabot-merge` job to `.github/workflows/build_docs.yml` that automatically approves and merges Dependabot pull requests after the `build` job succeeds.